### PR TITLE
refactor(edit): Replace arrayHolder with recursive write-back

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -3,73 +3,8 @@ package tree
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 )
-
-type arrayHolder struct{ a *Array }
-
-func (h *arrayHolder) IsNil() bool                               { return h.a.IsNil() }
-func (h *arrayHolder) Type() Type                                { return h.a.Type() }
-func (h *arrayHolder) Array() Array                              { return *h.a }
-func (h *arrayHolder) Map() Map                                  { return h.a.Map() }
-func (h *arrayHolder) Value() Value                              { return h.a.Value() }
-func (h *arrayHolder) Has(keys ...any) bool                      { return h.a.Has(keys...) }
-func (h *arrayHolder) Get(keys ...any) Node                      { return h.a.Get(keys...) }
-func (h *arrayHolder) Each(cb func(key any, v Node) error) error { return h.a.Each(cb) }
-func (h *arrayHolder) Find(expr string) ([]Node, error)          { return h.a.Find(expr) }
-func (h *arrayHolder) Delete(key any) error                      { return h.a.Delete(key) }
-func (h *arrayHolder) Append(v Node) error                       { return h.a.Append(*holdArray(&v)) }
-func (h *arrayHolder) Set(key any, v Node) error                 { return h.a.Set(key, *holdArray(&v)) }
-
-var _ EditorNode = (*arrayHolder)(nil)
-
-// holdArray wraps Array nodes with arrayHolder for edit operations.
-// Recursively processes nested structures.
-func holdArray(pn *Node) *Node {
-	n := *pn
-	if a := n.Array(); a != nil {
-		ah := &arrayHolder{&a}
-		*pn = ah
-		for i, nn := range a {
-			if nn != nil {
-				holdArray(&nn)
-				a[i] = nn
-			}
-		}
-	} else if m := n.Map(); m != nil {
-		for key, nn := range m {
-			if nn != nil {
-				holdArray(&nn)
-				m[key] = nn
-			}
-		}
-	}
-	return pn
-}
-
-// unholdArray unwraps arrayHolder nodes back to regular Array nodes.
-// Recursively processes nested structures.
-func unholdArray(pn *Node) {
-	n := *pn
-	if a := n.Array(); a != nil {
-		if ah, ok := n.(*arrayHolder); ok {
-			a = *ah.a
-			*pn = a
-		}
-		for i, nn := range a {
-			if nn != nil {
-				unholdArray(&nn)
-				a[i] = nn
-			}
-		}
-	} else if m := n.Map(); m != nil {
-		for key, nn := range m {
-			if nn != nil {
-				unholdArray(&nn)
-				m[key] = nn
-			}
-		}
-	}
-}
 
 var editRegexp = regexp.MustCompile(`^([^\+]+) ?((=|\+=) ?(.+)|(\^\?))$`)
 
@@ -97,9 +32,6 @@ func Edit(pn *Node, expr string) error {
 		return err
 	}
 
-	holdArray(pn)
-	defer unholdArray(pn)
-
 	return editQuery(pn, q, op, v)
 }
 
@@ -116,27 +48,253 @@ func editQuery(pn *Node, q Query, op string, v Node) error {
 }
 
 // execForEdit executes a FilterQuery for edit operations.
-// Handles multi-step queries for complex edit paths.
+// For multi-step queries it uses resolveAndEdit for recursive descent
+// with write-back, so that mutations to Array nodes (value types)
+// propagate back to their parents without wrapping the entire tree.
 func execForEdit(pn *Node, fq FilterQuery, op string, v Node) error {
 	l := len(fq)
 	if l == 0 {
 		return nil
 	}
+	if l == 1 {
+		return editQuery(pn, fq[0], op, v)
+	}
 
-	nn := []Node{*pn}
-	if l > 1 {
-		var err error
-		nn, err = fq.execForEdit(*pn)
-		if err != nil {
-			return err
+	// Split at SlurpQuery (pipe) if present among intermediate steps.
+	for i, q := range fq[:l-1] {
+		if _, ok := q.(SlurpQuery); ok {
+			left := FilterQuery(fq[:i])
+			right := FilterQuery(fq[i+1:])
+
+			var results []Node
+			if len(left) > 0 {
+				var err error
+				results, err = left.Exec(*pn)
+				if err != nil {
+					return err
+				}
+			} else {
+				results = []Node{*pn}
+			}
+
+			var slurped Node = Array(results)
+			return execForEdit(&slurped, right, op, v)
 		}
 	}
 
-	q := fq[l-1]
-	for _, n := range nn {
-		if err := editQuery(&n, q, op, v); err != nil {
+	return resolveAndEdit(pn, fq, 0, op, v)
+}
+
+// resolveAndEdit walks the FilterQuery path step by step, writing back
+// modified Array nodes at each level so changes propagate to the root.
+func resolveAndEdit(pn *Node, fq FilterQuery, step int, op string, v Node) error {
+	if step >= len(fq)-1 {
+		return editQuery(pn, fq[len(fq)-1], op, v)
+	}
+
+	q := fq[step]
+	n := *pn
+
+	switch tq := q.(type) {
+	case MapQuery:
+		return resolveMapStep(pn, n, string(tq), fq, step, op, v)
+
+	case ArrayQuery:
+		return resolveArrayStep(pn, n, int(tq), fq, step, op, v)
+
+	case WalkQuery:
+		key := string(tq)
+		return Walk(n, func(wn Node, keys []any) error {
+			if wn.Has(key) {
+				if en, ok := wn.(EditorNode); ok {
+					child := wn.Get(key)
+
+					if err := resolveAndEdit(&child, fq, step+1, op, v); err != nil {
+						return err
+					}
+
+					return en.Set(key, child)
+				}
+			}
+			return nil
+		})
+
+	case SelectQuery:
+		return resolveSelectStep(pn, n, tq, fq, step, op, v)
+
+	default:
+		// Fallback: use Exec (no write-back, works for reference types).
+		results, err := q.Exec(n)
+		if err != nil {
 			return err
 		}
+		for _, r := range results {
+			child := r
+
+			if err := resolveAndEdit(&child, fq, step+1, op, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// resolveMapStep handles a MapQuery intermediate step with write-back.
+func resolveMapStep(pn *Node, n Node, key string, fq FilterQuery, step int, op string, v Node) error {
+	if m := n.Map(); m != nil {
+		child, exists := m[key]
+		if !exists || child == nil {
+			child = emptyIntermediate(fq[step+1])
+			if child == nil {
+				return nil
+			}
+			m[key] = child
+		}
+
+		if err := resolveAndEdit(&child, fq, step+1, op, v); err != nil {
+			return err
+		}
+
+		m[key] = child
+		return nil
+	}
+
+	if a := n.Array(); a != nil {
+		i, err := strconv.Atoi(key)
+		if err != nil || i < 0 {
+			return nil
+		}
+		if i >= len(a) {
+			na := make(Array, i+1)
+			copy(na, a)
+			a = na
+		}
+		child := a[i]
+		if child == nil {
+			child = emptyIntermediate(fq[step+1])
+			if child == nil {
+				return nil
+			}
+		}
+
+		if err := resolveAndEdit(&child, fq, step+1, op, v); err != nil {
+			return err
+		}
+
+		a[i] = child
+		*pn = a
+		return nil
+	}
+
+	return nil
+}
+
+// resolveArrayStep handles an ArrayQuery intermediate step with write-back.
+func resolveArrayStep(pn *Node, n Node, index int, fq FilterQuery, step int, op string, v Node) error {
+	if en, ok := n.(EditorNode); ok {
+		child := n.Get(index)
+		if child.IsNil() {
+			child = emptyIntermediate(fq[step+1])
+			if child == nil {
+				return nil
+			}
+			if err := en.Set(index, child); err != nil {
+				return err
+			}
+		}
+
+		if err := resolveAndEdit(&child, fq, step+1, op, v); err != nil {
+			return err
+		}
+
+		return en.Set(index, child)
+	}
+
+	if a := n.Array(); a != nil {
+		if index >= len(a) {
+			na := make(Array, index+1)
+			copy(na, a)
+			a = na
+		}
+		child := a[index]
+		if child == nil {
+			child = emptyIntermediate(fq[step+1])
+			if child == nil {
+				return nil
+			}
+		}
+
+		if err := resolveAndEdit(&child, fq, step+1, op, v); err != nil {
+			return err
+		}
+
+		a[index] = child
+		*pn = a
+		return nil
+	}
+
+	return nil
+}
+
+// resolveSelectStep handles a SelectQuery intermediate step with write-back.
+func resolveSelectStep(pn *Node, n Node, sq SelectQuery, fq FilterQuery, step int, op string, v Node) error {
+	if a := n.Array(); a != nil {
+		for i, elem := range a {
+			if sq.Selector != nil {
+				ok, err := sq.Matches(elem)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					continue
+				}
+			}
+			child := elem
+
+			if err := resolveAndEdit(&child, fq, step+1, op, v); err != nil {
+				return err
+			}
+
+			a[i] = child
+		}
+		*pn = a
+		return nil
+	}
+
+	if m := n.Map(); m != nil {
+		for _, k := range m.Keys() {
+			elem := m[k]
+			if sq.Selector != nil {
+				ok, err := sq.Matches(elem)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					continue
+				}
+			}
+			child := elem
+
+			if err := resolveAndEdit(&child, fq, step+1, op, v); err != nil {
+				return err
+			}
+
+			m[k] = child
+		}
+		return nil
+	}
+
+	return nil
+}
+
+// emptyIntermediate returns an empty node appropriate for the next
+// query step, or nil if no intermediate creation is needed.
+func emptyIntermediate(nextQuery Query) Node {
+	switch nextQuery.(type) {
+	case MapQuery:
+		return Map{}
+	case ArrayQuery:
+		return Array{}
 	}
 	return nil
 }

--- a/edit_test.go
+++ b/edit_test.go
@@ -5,44 +5,6 @@ import (
 	"testing"
 )
 
-func Test_holdArray(t *testing.T) {
-	var got Node = Array{
-		StringValue("0"),
-		Array{StringValue("0-0"), StringValue("0-1")},
-		Map{"1": Array{BoolValue(true)}},
-	}
-	want := &arrayHolder{
-		&Array{
-			StringValue("0"),
-			&arrayHolder{a: &Array{StringValue("0-0"), StringValue("0-1")}},
-			Map{"1": &arrayHolder{a: &Array{BoolValue(true)}}},
-		},
-	}
-	holdArray(&got)
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %#v; want %#v", got, want)
-	}
-}
-
-func Test_unholdArray(t *testing.T) {
-	var want Node = Array{
-		StringValue("0"),
-		Array{StringValue("0-0"), StringValue("0-1")},
-		Map{"1": Array{BoolValue(true)}},
-	}
-	var got Node = &arrayHolder{
-		&Array{
-			StringValue("0"),
-			&arrayHolder{a: &Array{StringValue("0-0"), StringValue("0-1")}},
-			Map{"1": &arrayHolder{a: &Array{BoolValue(true)}}},
-		},
-	}
-	unholdArray(&got)
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %#v; want %#v", got, want)
-	}
-}
-
 func Test_Edit(t *testing.T) {
 	testCases := []struct {
 		caseName string

--- a/edit_test.go
+++ b/edit_test.go
@@ -1,6 +1,7 @@
 package tree
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -310,7 +311,7 @@ func Test_Edit(t *testing.T) {
 			},
 		},
 
-		// --- Array holder scenarios (nested array mutations) ---
+		// --- Deep nested Array write-back (mutations through value-typed Arrays) ---
 		{
 			caseName: "append to array nested in map nested in array",
 			n: Array{
@@ -369,14 +370,14 @@ func Test_Edit(t *testing.T) {
 			},
 		}, {
 			caseName: "append to root array with existing elements",
-			n:    Array{StringValue("a"), StringValue("b")},
-			expr: `. += "c"`,
-			want: Array{StringValue("a"), StringValue("b"), StringValue("c")},
+			n:        Array{StringValue("a"), StringValue("b")},
+			expr:     `. += "c"`,
+			want:     Array{StringValue("a"), StringValue("b"), StringValue("c")},
 		}, {
 			caseName: "delete from root array",
-			n:    Array{StringValue("a"), StringValue("b"), StringValue("c")},
-			expr: `[1] ^?`,
-			want: Array{StringValue("a"), StringValue("c")},
+			n:        Array{StringValue("a"), StringValue("b"), StringValue("c")},
+			expr:     `[1] ^?`,
+			want:     Array{StringValue("a"), StringValue("c")},
 		}, {
 			caseName: "set grows array in nested structure",
 			n: Map{
@@ -433,19 +434,19 @@ func Test_Edit(t *testing.T) {
 			},
 		}, {
 			caseName: "set on array in array in array",
-			n:    Array{Array{Array{StringValue("deep")}}},
-			expr: `[0][0][0] = "new"`,
-			want: Array{Array{Array{StringValue("new")}}},
+			n:        Array{Array{Array{StringValue("deep")}}},
+			expr:     `[0][0][0] = "new"`,
+			want:     Array{Array{Array{StringValue("new")}}},
 		}, {
 			caseName: "append to array in array in array",
-			n:    Array{Array{Array{StringValue("a")}}},
-			expr: `[0][0] += "b"`,
-			want: Array{Array{Array{StringValue("a"), StringValue("b")}}},
+			n:        Array{Array{Array{StringValue("a")}}},
+			expr:     `[0][0] += "b"`,
+			want:     Array{Array{Array{StringValue("a"), StringValue("b")}}},
 		}, {
 			caseName: "delete from array in array in array",
-			n:    Array{Array{Array{StringValue("a"), StringValue("b")}}},
-			expr: `[0][0][0] ^?`,
-			want: Array{Array{Array{StringValue("b")}}},
+			n:        Array{Array{Array{StringValue("a"), StringValue("b")}}},
+			expr:     `[0][0][0] ^?`,
+			want:     Array{Array{Array{StringValue("b")}}},
 		}, {
 			caseName: "set replaces entire nested array",
 			n: Map{
@@ -457,14 +458,14 @@ func Test_Edit(t *testing.T) {
 			},
 		}, {
 			caseName: "edit with nil element in array",
-			n:    Array{nil, StringValue("b")},
-			expr: `[0] = "a"`,
-			want: Array{StringValue("a"), StringValue("b")},
+			n:        Array{nil, StringValue("b")},
+			expr:     `[0] = "a"`,
+			want:     Array{StringValue("a"), StringValue("b")},
 		}, {
 			caseName: "delete middle element from three-element array",
-			n:    Array{StringValue("a"), StringValue("b"), StringValue("c")},
-			expr: `[1] ^?`,
-			want: Array{StringValue("a"), StringValue("c")},
+			n:        Array{StringValue("a"), StringValue("b"), StringValue("c")},
+			expr:     `[1] ^?`,
+			want:     Array{StringValue("a"), StringValue("c")},
 		}, {
 			caseName: "append to empty nested array",
 			n: Map{
@@ -473,6 +474,170 @@ func Test_Edit(t *testing.T) {
 			expr: `.list += "first"`,
 			want: Map{
 				"list": Array{StringValue("first")},
+			},
+		},
+
+		// --- Edit-level parse / unmarshal errors ---
+		{
+			caseName: "invalid query expression returns parse error",
+			n:        Map{},
+			expr:     `[ = 1`,
+			errstr:   `syntax error: no right brackets: "[ "`,
+		}, {
+			caseName: "invalid YAML on RHS returns unmarshal error",
+			n:        Map{},
+			expr:     `.a = }not yaml`,
+			errstr:   `yaml: did not find expected node content`,
+		},
+
+		// --- Intermediate-step edge cases in resolveAndEdit ---
+		{
+			caseName: "pipe-prefixed query slurps root then edits wrapper",
+			n:        Map{"a": StringValue("v")},
+			expr:     `| [0] = "x"`,
+			want:     Map{"a": StringValue("v")},
+		}, {
+			caseName: "NopQuery as intermediate step uses default branch",
+			n:        Map{},
+			expr:     `..[0] = 1`,
+			want:     Map{"0": NumberValue(1)},
+		}, {
+			caseName: "missing map key with non-collection next is a no-op",
+			n:        Map{},
+			expr:     `.missing[].x = 1`,
+			want:     Map{},
+		}, {
+			caseName: "non-numeric map key on Array is a no-op",
+			n:        Map{"arr": Array{NumberValue(1)}},
+			expr:     `.arr.badkey.x = 1`,
+			want:     Map{"arr": Array{NumberValue(1)}},
+		}, {
+			caseName: "nil element at Array MapQuery step with non-collection next is a no-op",
+			n:        Map{"arr": Array{nil, nil}},
+			expr:     `.arr.0[].x = 1`,
+			want:     Map{"arr": Array{nil, nil}},
+		}, {
+			caseName: "nil element at Array ArrayQuery step with non-collection next is a no-op",
+			n:        Array{nil, nil},
+			expr:     `[0][].x = 1`,
+			want:     Array{nil, nil},
+		}, {
+			caseName: "MapQuery intermediate on non-collection is a no-op",
+			n:        Map{"s": StringValue("hi")},
+			expr:     `.s.x.y = 1`,
+			want:     Map{"s": StringValue("hi")},
+		}, {
+			caseName: "ArrayQuery intermediate on non-collection is a no-op",
+			n:        Map{"s": StringValue("hi")},
+			expr:     `.s[0].x = 1`,
+			want:     Map{"s": StringValue("hi")},
+		}, {
+			caseName: "ArrayQuery intermediate on Map uses EditorNode branch",
+			n:        Map{"m": Map{"0": Map{"x": StringValue("old")}}},
+			expr:     `.m[0].x = "new"`,
+			want:     Map{"m": Map{"0": Map{"x": StringValue("new")}}},
+		}, {
+			caseName: "ArrayQuery intermediate on Map creates missing key via emptyIntermediate",
+			n:        Map{"arr": Map{"x": StringValue("v")}},
+			expr:     `.arr[0].y = 1`,
+			want:     Map{"arr": Map{"0": Map{"y": NumberValue(1)}, "x": StringValue("v")}},
+		}, {
+			caseName: "SelectQuery intermediate iterates Map values",
+			n: Map{
+				"items": Map{
+					"a": Map{"active": BoolValue(true), "name": StringValue("old")},
+					"b": Map{"active": BoolValue(false), "name": StringValue("old2")},
+				},
+			},
+			expr: `.items[].name = "new"`,
+			want: Map{
+				"items": Map{
+					"a": Map{"active": BoolValue(true), "name": StringValue("new")},
+					"b": Map{"active": BoolValue(false), "name": StringValue("new")},
+				},
+			},
+		},
+
+		// --- Recursion error propagation from terminal step ---
+		{
+			caseName: "error from MapQuery terminal propagates through map step",
+			n:        Map{"s": StringValue("hi")},
+			expr:     `.s.x = 1`,
+			errstr:   `cannot index array with "x"`,
+		}, {
+			caseName: "error from MapQuery terminal propagates through Array map step",
+			n:        Map{"arr": Array{StringValue("hi")}},
+			expr:     `.arr.0.x = 1`,
+			errstr:   `cannot index array with "x"`,
+		}, {
+			caseName: "error from MapQuery terminal propagates through ArrayQuery step",
+			n:        Array{StringValue("hi")},
+			expr:     `[0].x = 1`,
+			errstr:   `cannot index array with "x"`,
+		}, {
+			caseName: "error from SelectQuery Array branch propagates through iteration",
+			n:        Map{"items": Array{StringValue("oops")}},
+			expr:     `.items[].name = "x"`,
+			errstr:   `cannot index array with "name"`,
+		}, {
+			caseName: "error from SelectQuery Map branch propagates through iteration",
+			n:        Map{"items": Map{"a": StringValue("oops")}},
+			expr:     `.items[].name = "x"`,
+			errstr:   `cannot index array with "name"`,
+		}, {
+			caseName: "error from WalkQuery intermediate recursion propagates up",
+			n:        Map{"outer": Map{"name": StringValue("str")}},
+			expr:     `..name.x = 1`,
+			errstr:   `cannot index array with "x"`,
+		}, {
+			caseName: "error from default-branch terminal step propagates up",
+			n:        Array{StringValue("hi")},
+			expr:     `..[0].x = 1`,
+			errstr:   `cannot index array with "x"`,
+		}, {
+			caseName: "EditorNode ArrayQuery intermediate with missing key and non-collection next is a no-op",
+			n:        Map{"arr": Map{"x": StringValue("v")}},
+			expr:     `.arr[0][].y = 1`,
+			want:     Map{"arr": Map{"x": StringValue("v")}},
+		}, {
+			caseName: "error from EditorNode ArrayQuery branch recursion propagates up",
+			n:        Map{"arr": Map{"0": StringValue("oops")}},
+			expr:     `.arr[0].x = 1`,
+			errstr:   `cannot index array with "x"`,
+		}, {
+			caseName: "default-branch intermediate Exec error propagates up",
+			n:        Map{"items": Map{"x": StringValue("v")}},
+			expr:     `.items[1:2].x = 1`,
+			errstr:   `cannot index array with range 1:2`,
+		}, {
+			caseName: "slurp left.Exec error propagates up",
+			n:        Map{"items": Map{"x": StringValue("v")}},
+			expr:     `.items[1:2] | .x = 1`,
+			errstr:   `cannot index array with range 1:2`,
+		}, {
+			caseName: "terminal SelectQuery is an unsupported edit query",
+			n:        Map{"items": Array{NumberValue(1)}},
+			expr:     `.items[] = "new"`,
+			errstr:   `syntax error: unsupported edit query: []`,
+		}, {
+			caseName: "SelectQuery intermediate on non-collection is a no-op",
+			n:        Map{"s": StringValue("hi")},
+			expr:     `.s[].x = 1`,
+			want:     Map{"s": StringValue("hi")},
+		}, {
+			caseName: "SelectQuery with selector iterates Map values matching comparator",
+			n: Map{
+				"items": Map{
+					"a": Map{"x": NumberValue(1), "name": StringValue("old")},
+					"b": Map{"x": NumberValue(2), "name": StringValue("old2")},
+				},
+			},
+			expr: `.items[.x == 1].name = "new"`,
+			want: Map{
+				"items": Map{
+					"a": Map{"x": NumberValue(1), "name": StringValue("new")},
+					"b": Map{"x": NumberValue(2), "name": StringValue("old2")},
+				},
 			},
 		},
 	}
@@ -494,6 +659,42 @@ func Test_Edit(t *testing.T) {
 			got := tc.n
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("got %#v; want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_Edit_resolveSelectStep_SelectorError(t *testing.T) {
+	selector := &testSelectorDelegator{
+		matchesFunc: func(Node) (bool, error) {
+			return false, errors.New("selector boom")
+		},
+	}
+	fq := FilterQuery{
+		MapQuery("items"),
+		SelectQuery{Selector: selector},
+		MapQuery("name"),
+	}
+	testCases := []struct {
+		caseName string
+		n        Node
+	}{
+		{
+			caseName: "Array branch propagates selector error",
+			n:        Map{"items": Array{Map{"name": StringValue("a")}}},
+		}, {
+			caseName: "Map branch propagates selector error",
+			n:        Map{"items": Map{"a": Map{"name": StringValue("a")}}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := resolveAndEdit(&tc.n, fq, 0, "=", StringValue("x"))
+			if err == nil {
+				t.Fatalf("no error; want %q", "selector boom")
+			}
+			if err.Error() != "selector boom" {
+				t.Errorf("got error %q; want %q", err.Error(), "selector boom")
 			}
 		})
 	}

--- a/query.go
+++ b/query.go
@@ -42,10 +42,9 @@ func (q NopQuery) Set(pn *Node, v Node) error {
 }
 
 func (q NopQuery) Append(pn *Node, v Node) error {
-	if en, ok := (*pn).(EditorNode); ok {
-		if err := en.Append(v); err == nil {
-			return nil
-		}
+	if a := (*pn).Array(); a != nil {
+		*pn = append(a, v)
+		return nil
 	}
 	return fmt.Errorf("cannot append to %s", ".")
 }
@@ -93,21 +92,24 @@ func (q MapQuery) Set(pn *Node, v Node) error {
 	if en, ok := (*pn).(EditorNode); ok {
 		return en.Set(key, v)
 	}
+	if a := (*pn).Array(); a != nil {
+		if err := a.Set(key, v); err != nil {
+			return err
+		}
+
+		*pn = a
+		return nil
+	}
 	return fmt.Errorf("cannot index array with %q", key)
 }
 
 func (q MapQuery) Append(pn *Node, v Node) error {
 	n := *pn
 	key := string(q)
-	if en, ok := (*pn).(EditorNode); ok {
+	if en, ok := n.(EditorNode); ok {
 		if n.Has(key) {
-			x := n.Get(key)
-			if x != nil {
-				if ex, ok := x.(EditorNode); ok {
-					if err := ex.Append(v); err == nil {
-						return nil
-					}
-				}
+			if ca := n.Get(key).Array(); ca != nil {
+				return en.Set(key, append(ca, v))
 			}
 			return fmt.Errorf("cannot append to %q", key)
 		}
@@ -122,6 +124,14 @@ func (q MapQuery) Delete(pn *Node) error {
 		if err := en.Delete(key); err == nil {
 			return nil
 		}
+	}
+	if a := (*pn).Array(); a != nil {
+		if err := a.Delete(key); err != nil {
+			return fmt.Errorf("cannot delete %q", key)
+		}
+
+		*pn = a
+		return nil
 	}
 	return fmt.Errorf("cannot delete %q", key)
 }
@@ -151,25 +161,43 @@ func (q ArrayQuery) Set(pn *Node, v Node) error {
 	if en, ok := (*pn).(EditorNode); ok {
 		return en.Set(index, v)
 	}
+	if a := (*pn).Array(); a != nil {
+		if err := a.Set(index, v); err != nil {
+			return err
+		}
+
+		*pn = a
+		return nil
+	}
 	return fmt.Errorf("cannot index array with %d", index)
 }
 
 func (q ArrayQuery) Append(pn *Node, v Node) error {
 	index := int(q)
 	n := *pn
-	if en, ok := (*pn).(EditorNode); ok {
+	if en, ok := n.(EditorNode); ok {
 		if n.Has(index) {
-			x := n.Get(index)
-			if x != nil {
-				if ex, ok := x.(EditorNode); ok {
-					if err := ex.Append(v); err == nil {
-						return nil
-					}
-				}
+			if ca := n.Get(index).Array(); ca != nil {
+				return en.Set(index, append(ca, v))
 			}
 			return fmt.Errorf("cannot append to array with %d", index)
 		}
 		return en.Set(index, Array{v})
+	}
+	if a := n.Array(); a != nil {
+		if n.Has(index) {
+			if ca := a[index].Array(); ca != nil {
+				a[index] = append(ca, v)
+				*pn = a
+				return nil
+			}
+			return fmt.Errorf("cannot append to array with %d", index)
+		}
+		na := make(Array, index+1)
+		copy(na, a)
+		na[index] = Array{v}
+		*pn = na
+		return nil
 	}
 	return fmt.Errorf("cannot append to array with %d", index)
 }
@@ -180,6 +208,14 @@ func (q ArrayQuery) Delete(pn *Node) error {
 		if err := en.Delete(index); err == nil {
 			return nil
 		}
+	}
+	if a := (*pn).Array(); a != nil {
+		if err := a.Delete(index); err != nil {
+			return fmt.Errorf("cannot delete array with %d", index)
+		}
+
+		*pn = a
+		return nil
 	}
 	return fmt.Errorf("cannot delete array with %d", index)
 }
@@ -262,53 +298,6 @@ func (qs FilterQuery) Exec(n Node) ([]Node, error) {
 	return rs, nil
 }
 
-func (qs FilterQuery) execForEdit(n Node) ([]Node, error) {
-	rs := []Node{n}
-	for i, q := range qs[:len(qs)-1] {
-		switch q.(type) {
-		case SlurpQuery:
-			nrs, err := q.Exec(Array(rs))
-			if err != nil {
-				return nil, err
-			}
-			rs = nrs
-			continue
-		}
-		var nrs []Node
-		for _, r := range rs {
-			if r == nil {
-				continue
-			}
-			nr, err := q.Exec(r)
-			if err != nil {
-				return nil, err
-			}
-			if len(nr) == 0 {
-				var empty Node
-				switch qs[i+1].(type) {
-				case MapQuery:
-					empty = Map{}
-				case ArrayQuery:
-					empty = Array{}
-				}
-				if empty != nil {
-					if eq, ok := q.(EditorQuery); ok {
-						if err = eq.Set(&r, empty); err != nil {
-							return nil, err
-						}
-						if nr, err = eq.Exec(r); err != nil {
-							return nil, err
-						}
-					}
-				}
-			}
-			nrs = append(nrs, nr...)
-		}
-		rs = nrs
-	}
-	return rs, nil
-}
-
 func (qs FilterQuery) String() string {
 	ss := make([]string, len(qs))
 	for i, q := range qs {
@@ -355,9 +344,9 @@ func (q WalkQuery) Append(pn *Node, v Node) error {
 	key := string(q)
 	return Walk(*pn, func(n Node, keys []any) error {
 		if n.Has(key) {
-			if nv := n.Get(key); nv != nil {
-				if env, ok := nv.(EditorNode); ok {
-					_ = env.Append(v)
+			if ca := n.Get(key).Array(); ca != nil {
+				if en, ok := n.(EditorNode); ok {
+					_ = en.Set(key, append(ca, v))
 				}
 			}
 		}

--- a/query_test.go
+++ b/query_test.go
@@ -622,3 +622,22 @@ func BenchmarkFind(b *testing.B) {
 	}
 }
 
+// testSelectorDelegator is a test-only Selector whose Matches behavior
+// can be configured per-test by assigning matchesFunc. It exists so
+// that tests can exercise Selector error paths and custom match logic
+// that parser-produced selectors cannot easily produce.
+type testSelectorDelegator struct {
+	matchesFunc func(Node) (bool, error)
+}
+
+func (d *testSelectorDelegator) Matches(n Node) (bool, error) {
+	if d.matchesFunc != nil {
+		return d.matchesFunc(n)
+	}
+	return false, nil
+}
+
+func (d *testSelectorDelegator) String() string {
+	return "testSelectorDelegator"
+}
+


### PR DESCRIPTION
## Summary

Replaces the `arrayHolder` / `holdArray` / `unholdArray` tree-wrapping approach in `Edit()` with a recursive, path-local write-back strategy (`resolveAndEdit`). The old approach rewrapped every `Array` in the tree with a pointer-backed holder before editing and unwrapped them afterwards — two full tree walks per `Edit()` call, plus a wrapper type that leaked into every type assertion downstream. The new approach walks only the edit path and writes mutated `Array` values back into their parents one step at a time.

## Benchmarks

Apple M4, `go test -bench=BenchmarkEdit -count=6 -cpu=1`. `before` = arrayHolder (parent of this PR), `after` = this PR.

```
                         │    before (arrayHolder)     │     after (resolveAndEdit)          │
                         │           sec/op            │   sec/op     vs base                │
Edit/set_shallow                          34.41µ ± 2%   27.16µ ± 1%  -21.05% (p=0.002 n=6)
Edit/set_deep_array                       35.69µ ± 1%   28.59µ ± 1%  -19.90% (p=0.002 n=6)
Edit/append_to_array                      36.35µ ± 1%   29.45µ ± 1%  -18.97% (p=0.002 n=6)
Edit/delete_from_array                    32.24µ ± 1%   26.20µ ± 0%  -18.74% (p=0.002 n=6)
Edit/walk_set                             42.38µ ± 1%   36.40µ ± 2%  -14.12% (p=0.002 n=6)
Edit/filtered_set                         38.70µ ± 1%   31.71µ ± 1%  -18.07% (p=0.002 n=6)
Edit/nested_array_append                  38.27µ ± 1%   31.43µ ± 1%  -17.87% (p=0.002 n=6)
geomean                                   36.74µ        29.97µ       -18.41%

                         │            B/op             │     B/op      vs base               │
Edit/set_shallow                         33.96Ki ± 0%   29.90Ki ± 0%  -11.96% (p=0.002 n=6)
Edit/set_deep_array                      34.95Ki ± 0%   30.87Ki ± 0%  -11.69% (p=0.002 n=6)
Edit/append_to_array                     39.16Ki ± 0%   35.08Ki ± 0%  -10.41% (p=0.002 n=6)
Edit/delete_from_array                   29.01Ki ± 0%   25.23Ki ± 0%  -13.03% (p=0.002 n=6)
Edit/walk_set                            46.36Ki ± 0%   42.52Ki ± 0%   -8.29% (p=0.002 n=6)
Edit/filtered_set                        37.21Ki ± 0%   33.06Ki ± 0%  -11.15% (p=0.002 n=6)
Edit/nested_array_append                 40.68Ki ± 0%   36.49Ki ± 0%  -10.31% (p=0.002 n=6)
geomean                                  36.98Ki        32.92Ki       -10.99%

                         │         allocs/op           │  allocs/op   vs base                │
Edit/set_shallow                          1059.0 ± 0%    833.0 ± 0%  -21.34% (p=0.002 n=6)
Edit/set_deep_array                       1074.0 ± 0%    846.0 ± 0%  -21.23% (p=0.002 n=6)
Edit/append_to_array                      1086.0 ± 0%    860.0 ± 0%  -20.81% (p=0.002 n=6)
Edit/delete_from_array                    1018.0 ± 0%    809.0 ± 0%  -20.53% (p=0.002 n=6)
Edit/walk_set                             1.418k ± 0%   1.206k ± 0%  -14.95% (p=0.002 n=6)
Edit/filtered_set                         1136.0 ± 0%    909.0 ± 0%  -19.98% (p=0.002 n=6)
Edit/nested_array_append                  1114.0 ± 0%    880.0 ± 0%  -21.01% (p=0.002 n=6)
geomean                                   1.123k         898.6       -20.01%
```

- Time: **-18.41%** (geomean)
- Memory: **-10.99%** (geomean)
- Allocations: **-20.01%** (geomean)

All scenarios `p=0.002 (n=6)`.

## Coverage

Second commit raises `edit.go` coverage from ~86% to **97.4% (113/116 blocks)**. The remaining 3 uncovered blocks are defensive guards that cannot be reached through the public `Edit()` API (0-length `FilterQuery`, `Map.Set(int,...)` error, and `execEdit`'s operator default — all protected by upstream invariants).

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] Coverage of `edit.go` measured before/after
- [x] `BenchmarkEdit` (7 scenarios) compared with `benchstat`