### PR TITLE
feat: Add V helper as a short alias for ToValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Tree is a simple structure for dealing with dynamic or unknown JSON/YAML in Go.
 
 ```go
 tree.Map{
-	"ID":     tree.ToValue(1),
-	"Name":   tree.ToValue("Reds"),
+	"ID":     tree.V(1),
+	"Name":   tree.V("Reds"),
 	"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 }
 ```
@@ -75,8 +75,8 @@ Colors:
 ```go
 func ExampleMarshalJSON() {
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := json.Marshal(group)
@@ -164,8 +164,8 @@ func main() {
 ```go
 func ExampleGet() {
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 		"Nil":    nil,
 	}
@@ -187,8 +187,8 @@ func ExampleGet() {
 ```go
 func ExampleFind() {
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 
@@ -348,8 +348,8 @@ node.Find(".store.book.rsort(\".price\")")  // Books ordered by descending price
 ```go
 func ExampleEdit() {
 	var group tree.Node = tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -11,8 +11,8 @@ import (
 
 func ExampleMarshalJSON() {
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := json.Marshal(group)
@@ -104,8 +104,8 @@ func ExampleUnmarshalJSON_combined() {
 
 func ExampleMarshalYAML() {
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := tree.MarshalYAML(group)
@@ -147,8 +147,8 @@ Name: Reds
 
 func ExampleNode_Get() {
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 		"Nil":    nil,
 	}
@@ -175,8 +175,8 @@ func ExampleNode_Get() {
 
 func ExampleFind() {
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 
@@ -195,8 +195,8 @@ func ExampleFind() {
 
 func ExampleEdit() {
 	var group tree.Node = tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 

--- a/examples/custom_query_test.go
+++ b/examples/custom_query_test.go
@@ -29,18 +29,18 @@ func (q *evenIndexQuery) String() string {
 func Example_customQuery() {
 	group := tree.Array{
 		tree.Map{
-			"ID":     tree.ToValue(1),
-			"Name":   tree.ToValue("Reds"),
+			"ID":     tree.V(1),
+			"Name":   tree.V("Reds"),
 			"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 		},
 		tree.Map{
-			"ID":     tree.ToValue(2),
-			"Name":   tree.ToValue("Greens"),
+			"ID":     tree.V(2),
+			"Name":   tree.V("Greens"),
 			"Colors": tree.ToArrayValues("Green", "Lime", "Olive", "Teal"),
 		},
 		tree.Map{
-			"ID":     tree.ToValue(3),
-			"Name":   tree.ToValue("Blues"),
+			"ID":     tree.V(3),
+			"Name":   tree.V("Blues"),
 			"Colors": tree.ToArrayValues("Aqua", "Blue", "Cyan", "SkyBlue"),
 		},
 	}
@@ -82,18 +82,18 @@ func (s *primaryColorSelector) String() string {
 func Example_customSelector() {
 	group := tree.Array{
 		tree.Map{
-			"ID":     tree.ToValue(1),
-			"Name":   tree.ToValue("Reds"),
+			"ID":     tree.V(1),
+			"Name":   tree.V("Reds"),
 			"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 		},
 		tree.Map{
-			"ID":     tree.ToValue(2),
-			"Name":   tree.ToValue("Greens"),
+			"ID":     tree.V(2),
+			"Name":   tree.V("Greens"),
 			"Colors": tree.ToArrayValues("Green", "Lime", "Olive", "Teal"),
 		},
 		tree.Map{
-			"ID":     tree.ToValue(3),
-			"Name":   tree.ToValue("Blues"),
+			"ID":     tree.V(3),
+			"Name":   tree.V("Blues"),
 			"Colors": tree.ToArrayValues("Aqua", "Blue", "Cyan", "SkyBlue"),
 		},
 	}

--- a/examples/without_encoding_json_test.go
+++ b/examples/without_encoding_json_test.go
@@ -48,8 +48,8 @@ func Example_goJSONUnmarshal_combined() {
 
 func Example_goJSONMarshal() {
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := gojson.Marshal(group)
@@ -107,8 +107,8 @@ func Example_jsonIteratorMarshal() {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := json.Marshal(group)

--- a/examples/without_gopkg_yaml_test.go
+++ b/examples/without_gopkg_yaml_test.go
@@ -32,8 +32,8 @@ Name: Reds
 
 func Example_yamlV3Marshal() {
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := yamlv3.Marshal(group)
@@ -84,8 +84,8 @@ Name: Reds
 
 func Example_goYAMLMarshal() {
 	group := tree.Map{
-		"ID":     tree.ToValue(1),
-		"Name":   tree.ToValue("Reds"),
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
 		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := goyaml.Marshal(group)

--- a/util.go
+++ b/util.go
@@ -7,6 +7,14 @@ import (
 	"sync"
 )
 
+// V is a short alias for [ToValue]. It is intended to keep
+// composite-literal construction of [Map] / [Array] concise:
+//
+//	tree.Map{"Name": tree.V("Alice"), "Age": tree.V(30)}
+func V(v any) Node {
+	return ToValue(v)
+}
+
 // ToValue converts the specified v to a Value as Node.
 // Node.Value() returns converted value.
 func ToValue(v any) Node {

--- a/util_test.go
+++ b/util_test.go
@@ -5,6 +5,17 @@ import (
 	"testing"
 )
 
+func Test_V(t *testing.T) {
+	// V is a thin alias for ToValue; sample a few representative
+	// inputs to confirm they yield identical results.
+	inputs := []any{nil, "s", true, 1, int64(2), 3.5}
+	for _, in := range inputs {
+		if got, want := V(in), ToValue(in); got != want {
+			t.Errorf("V(%v) = %#v; want %#v", in, got, want)
+		}
+	}
+}
+
 func Test_ToValue(t *testing.T) {
 	tests := []struct {
 		v    any


### PR DESCRIPTION
## Summary
- Add `V` as a short alias for `ToValue` to keep composite-literal `Map` / `Array` construction concise:
  ```go
  tree.Map{"Name": tree.V("Alice"), "Age": tree.V(30)}
  ```
- Replace `tree.ToValue(...)` calls in `README.md`, `example_test.go`, and `examples/` with `tree.V(...)`
- `ToValue` itself is unchanged and still exported

## Test plan
- [x] `go test ./...` passes
- [x] `go test ./...` in `examples/` passes