### PR TITLE
feat: Add A helper as a short alias for ToArrayValues

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Tree is a simple structure for dealing with dynamic or unknown JSON/YAML in Go.
 tree.Map{
 	"ID":     tree.V(1),
 	"Name":   tree.V("Reds"),
-	"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+	"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 }
 ```
 
@@ -77,7 +77,7 @@ func ExampleMarshalJSON() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := json.Marshal(group)
 	if err != nil {
@@ -166,7 +166,7 @@ func ExampleGet() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 		"Nil":    nil,
 	}
 	fmt.Println(group.Get("Colors").Get(1))
@@ -189,7 +189,7 @@ func ExampleFind() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 
 	rs, err := group.Find(".Colors[1:3]")
@@ -350,7 +350,7 @@ func ExampleEdit() {
 	var group tree.Node = tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 
 	if err := tree.Edit(&group, ".Colors += \"Pink\""); err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -13,7 +13,7 @@ func ExampleMarshalJSON() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := json.Marshal(group)
 	if err != nil {
@@ -34,7 +34,7 @@ func ExampleMarshalJSON_combined() {
 	group := ColorGroup{
 		ID:     1,
 		Name:   "Reds",
-		Colors: tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		Colors: tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := json.Marshal(group)
 	if err != nil {
@@ -106,7 +106,7 @@ func ExampleMarshalYAML() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := tree.MarshalYAML(group)
 	if err != nil {
@@ -149,7 +149,7 @@ func ExampleNode_Get() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 		"Nil":    nil,
 	}
 	fmt.Println(group.Get("Colors").Get(1))
@@ -177,7 +177,7 @@ func ExampleFind() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 
 	rs, err := group.Find(".Colors[1:3]")
@@ -197,7 +197,7 @@ func ExampleEdit() {
 	var group tree.Node = tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 
 	if err := tree.Edit(&group, ".Colors += \"Pink\""); err != nil {

--- a/examples/custom_query_test.go
+++ b/examples/custom_query_test.go
@@ -31,17 +31,17 @@ func Example_customQuery() {
 		tree.Map{
 			"ID":     tree.V(1),
 			"Name":   tree.V("Reds"),
-			"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+			"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 		},
 		tree.Map{
 			"ID":     tree.V(2),
 			"Name":   tree.V("Greens"),
-			"Colors": tree.ToArrayValues("Green", "Lime", "Olive", "Teal"),
+			"Colors": tree.A("Green", "Lime", "Olive", "Teal"),
 		},
 		tree.Map{
 			"ID":     tree.V(3),
 			"Name":   tree.V("Blues"),
-			"Colors": tree.ToArrayValues("Aqua", "Blue", "Cyan", "SkyBlue"),
+			"Colors": tree.A("Aqua", "Blue", "Cyan", "SkyBlue"),
 		},
 	}
 
@@ -84,17 +84,17 @@ func Example_customSelector() {
 		tree.Map{
 			"ID":     tree.V(1),
 			"Name":   tree.V("Reds"),
-			"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+			"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 		},
 		tree.Map{
 			"ID":     tree.V(2),
 			"Name":   tree.V("Greens"),
-			"Colors": tree.ToArrayValues("Green", "Lime", "Olive", "Teal"),
+			"Colors": tree.A("Green", "Lime", "Olive", "Teal"),
 		},
 		tree.Map{
 			"ID":     tree.V(3),
 			"Name":   tree.V("Blues"),
-			"Colors": tree.ToArrayValues("Aqua", "Blue", "Cyan", "SkyBlue"),
+			"Colors": tree.A("Aqua", "Blue", "Cyan", "SkyBlue"),
 		},
 	}
 

--- a/examples/without_encoding_json_test.go
+++ b/examples/without_encoding_json_test.go
@@ -50,7 +50,7 @@ func Example_goJSONMarshal() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := gojson.Marshal(group)
 	if err != nil {
@@ -109,7 +109,7 @@ func Example_jsonIteratorMarshal() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := json.Marshal(group)
 	if err != nil {

--- a/examples/without_gopkg_yaml_test.go
+++ b/examples/without_gopkg_yaml_test.go
@@ -34,7 +34,7 @@ func Example_yamlV3Marshal() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := yamlv3.Marshal(group)
 	if err != nil {
@@ -86,7 +86,7 @@ func Example_goYAMLMarshal() {
 	group := tree.Map{
 		"ID":     tree.V(1),
 		"Name":   tree.V("Reds"),
-		"Colors": tree.ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
 	}
 	b, err := goyaml.Marshal(group)
 	if err != nil {

--- a/util.go
+++ b/util.go
@@ -15,6 +15,14 @@ func V(v any) Node {
 	return ToValue(v)
 }
 
+// A is a short alias for [ToArrayValues]. It pairs with [V] for concise
+// construction of arrays:
+//
+//	tree.A("Crimson", "Red", "Ruby")
+func A(vs ...any) Array {
+	return ToArrayValues(vs...)
+}
+
 // ToValue converts the specified v to a Value as Node.
 // Node.Value() returns converted value.
 func ToValue(v any) Node {

--- a/util_test.go
+++ b/util_test.go
@@ -16,6 +16,15 @@ func Test_V(t *testing.T) {
 	}
 }
 
+func Test_A(t *testing.T) {
+	// A is a thin alias for ToArrayValues.
+	got := A("a", 1, true)
+	want := ToArrayValues("a", 1, true)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("A(...) = %#v; want %#v", got, want)
+	}
+}
+
 func Test_ToValue(t *testing.T) {
 	tests := []struct {
 		v    any


### PR DESCRIPTION
## Summary
- Add `A` as a short alias for `ToArrayValues`, paired with `V` (#73) for concise composite-literal construction:
  ```go
  tree.A("Crimson", "Red", "Ruby")
  ```
- Replace `tree.ToArrayValues(...)` calls in `README.md`, `example_test.go`, and `examples/` with `tree.A(...)`
- `ToArrayValues` itself is unchanged and still exported

## Test plan
- [x] `go test ./...` passes
- [x] `go test ./...` in `examples/` passes