### PR TITLE
docs(examples): Add jsonschema validator examples

### DIFF
--- a/examples/jsonschema/go.mod
+++ b/examples/jsonschema/go.mod
@@ -1,0 +1,15 @@
+module jsonschema
+
+go 1.24.0
+
+toolchain go1.24.4
+
+require (
+	github.com/google/jsonschema-go v0.4.2
+	github.com/mojatter/tree v0.0.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+)
+
+require go.yaml.in/yaml/v3 v3.0.4 // indirect
+
+replace github.com/mojatter/tree => ../../

--- a/examples/jsonschema/go.sum
+++ b/examples/jsonschema/go.sum
@@ -1,0 +1,10 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/examples/jsonschema/jsonschema_test.go
+++ b/examples/jsonschema/jsonschema_test.go
@@ -1,0 +1,127 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	googlejsonschema "github.com/google/jsonschema-go/jsonschema"
+	"github.com/mojatter/tree"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+const groupSchema = `{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"type": "object",
+	"properties": {
+		"ID":     { "type": "integer" },
+		"Name":   { "type": "string" },
+		"Colors": { "type": "array", "items": { "type": "string" } }
+	},
+	"required": ["ID", "Name", "Colors"]
+}`
+
+// santhosh-tekuri/jsonschema/v5 type-switches on map[string]any / []any /
+// primitives internally, so tree nodes must be converted via tree.ToAny.
+func Example_santhoshtekuriValid() {
+	compiler := jsonschema.NewCompiler()
+	const id = "https://example.com/schema.json"
+	if err := compiler.AddResource(id, strings.NewReader(groupSchema)); err != nil {
+		log.Fatal(err)
+	}
+	schema, err := compiler.Compile(id)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	group := tree.Map{
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
+	}
+	// tree.ToAny copies the whole tree into plain Go values, which is
+	// expensive; Example_googleValid shows a validator that accepts tree
+	// nodes directly and skips this cost.
+	if err := schema.Validate(tree.ToAny(group)); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("valid")
+
+	// Output:
+	// valid
+}
+
+func Example_santhoshtekuriInvalid() {
+	compiler := jsonschema.NewCompiler()
+	const id = "https://example.com/schema.json"
+	if err := compiler.AddResource(id, strings.NewReader(groupSchema)); err != nil {
+		log.Fatal(err)
+	}
+	schema, err := compiler.Compile(id)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	group := tree.Map{
+		"ID":     tree.V("one"), // schema requires integer; this triggers the failure
+		"Name":   tree.V("Reds"),
+		"Colors": tree.A("Crimson"),
+	}
+	// tree.ToAny copies the whole tree into plain Go values, which is
+	// expensive; Example_googleValid shows a validator that accepts tree
+	// nodes directly and skips this cost.
+	fmt.Println(schema.Validate(tree.ToAny(group)))
+
+	// Output:
+	// jsonschema: '/ID' does not validate with https://example.com/schema.json#/properties/ID/type: expected integer, but got string
+}
+
+// google/jsonschema-go walks values via reflection, so tree.Map / tree.Array /
+// tree.StringValue / tree.NumberValue / tree.BoolValue are accepted directly.
+// Note that the tree.Any wrapper (a struct embedding Node) is not accepted;
+// unmarshal into tree.Map / tree.Array directly when using this validator.
+func Example_googleValid() {
+	var s googlejsonschema.Schema
+	if err := json.Unmarshal([]byte(groupSchema), &s); err != nil {
+		log.Fatal(err)
+	}
+	resolved, err := s.Resolve(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	group := tree.Map{
+		"ID":     tree.V(1),
+		"Name":   tree.V("Reds"),
+		"Colors": tree.A("Crimson", "Red", "Ruby", "Maroon"),
+	}
+	if err := resolved.Validate(group); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("valid")
+
+	// Output:
+	// valid
+}
+
+func Example_googleInvalid() {
+	var s googlejsonschema.Schema
+	if err := json.Unmarshal([]byte(groupSchema), &s); err != nil {
+		log.Fatal(err)
+	}
+	resolved, err := s.Resolve(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	group := tree.Map{
+		"ID":     tree.V("one"), // schema requires integer; this triggers the failure
+		"Name":   tree.V("Reds"),
+		"Colors": tree.A("Crimson"),
+	}
+	fmt.Println(resolved.Validate(group))
+
+	// Output:
+	// validating root: validating /properties/ID: type: one has type "string", want "integer"
+}


### PR DESCRIPTION
## Summary
- Add `examples/jsonschema/` with four runnable examples that contrast two validators against a shared `groupSchema`.
- `santhosh-tekuri/jsonschema/v5` requires `tree.ToAny` conversion because it type-switches on `map[string]any` / `[]any` / primitives internally.
- `google/jsonschema-go` walks values via reflection and accepts tree nodes (`tree.Map` / `tree.Array` / `StringValue` / `NumberValue` / `BoolValue`) directly — no conversion, no extra allocation.
- Each validator ships a Valid and an Invalid case so error output is visible in godoc.

## Test plan
- [x] `cd examples/jsonschema && go test ./...`