### PR TITLE
refactor(tree): Promote StoreJSON to internal/testdata

### DIFF
--- a/internal/testdata/store.go
+++ b/internal/testdata/store.go
@@ -1,0 +1,67 @@
+// Package testdata provides sample JSON fixtures used by tree and
+// its subpackages for tests, benchmarks, and godoc examples. It is
+// intentionally internal so the fixtures do not surface in the
+// public API of the tree module.
+package testdata
+
+// StoreJSON is the "Illustrative Object" from tree's README: a
+// bookstore document with nested arrays and maps. It is the default
+// fixture for query, editing, and validation examples.
+const StoreJSON = `{
+  "store": {
+    "book": [
+      {
+        "category": "reference",
+        "author": "Nigel Rees",
+        "authors": ["Nigel Rees"],
+        "title": "Sayings of the Century",
+        "price": 8.95,
+        "tags": [
+          { "name": "genre", "value": "reference" },
+          { "name": "era", "value": "20th century" },
+          { "name": "theme", "value": "quotations" }
+        ]
+      },
+      {
+        "category": "fiction",
+        "author": "Evelyn Waugh",
+        "title": "Sword of Honour",
+        "price": 12.99,
+        "tags": [
+          { "name": "genre", "value": "fiction" },
+          { "name": "era", "value": "20th century" },
+          { "name": "theme", "value": "WWII" }
+        ]
+      },
+      {
+        "category": "fiction",
+        "author": "Herman Melville",
+        "title": "Moby Dick",
+        "isbn": "0-553-21311-3",
+        "price": 8.99,
+        "tags": [
+          { "name": "genre", "value": "fiction" },
+          { "name": "era", "value": "19th century" },
+          { "name": "theme", "value": "whale hunting" }
+        ]
+      },
+      {
+        "category": "fiction",
+        "author": "J. R. R. Tolkien",
+        "title": "The Lord of the Rings",
+        "isbn": "0-395-19395-8",
+        "price": 22.99,
+        "tags": [
+          { "name": "genre", "value": "fantasy" },
+          { "name": "era", "value": "20th century" },
+          { "name": "theme", "value": "good vs evil" }
+        ]
+      }
+    ],
+    "bicycle": {
+      "color": "red",
+      "price": 19.95
+    }
+  }
+}
+`

--- a/internal/testdata/store.go
+++ b/internal/testdata/store.go
@@ -7,6 +7,9 @@ package testdata
 // StoreJSON is the "Illustrative Object" from tree's README: a
 // bookstore document with nested arrays and maps. It is the default
 // fixture for query, editing, and validation examples.
+//
+// Adapted from the jq wiki:
+// https://github.com/stedolan/jq/wiki/For-JSONPath-users#illustrative-object
 const StoreJSON = `{
   "store": {
     "book": [

--- a/json_test.go
+++ b/json_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/mojatter/tree/internal/testdata"
 )
 
 func Test_MarshalJSON(t *testing.T) {
@@ -283,7 +285,7 @@ func FuzzUnmarshalJSON(f *testing.F) {
 // BenchmarkUnmarshalJSON measures decoding the embedded sample
 // document into a Node tree.
 func BenchmarkUnmarshalJSON(b *testing.B) {
-	data := []byte(benchStoreJSON)
+	data := []byte(testdata.StoreJSON)
 	for i := 0; i < b.N; i++ {
 		if _, err := UnmarshalJSON(data); err != nil {
 			b.Fatal(err)

--- a/query_test.go
+++ b/query_test.go
@@ -3,6 +3,8 @@ package tree
 import (
 	"reflect"
 	"testing"
+
+	"github.com/mojatter/tree/internal/testdata"
 )
 
 func Test_Query(t *testing.T) {
@@ -317,67 +319,9 @@ func Test_ParseQuery_Errors(t *testing.T) {
 }
 
 // NOTE: Copy from https://github.com/stedolan/jq/wiki/For-JSONPath-users#illustrative-object
-var testStoreJSON = `{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "authors": ["Nigel Rees"],
-        "title": "Sayings of the Century",
-        "price": 8.95,
-        "tags": [
-          { "name": "genre", "value": "reference" },
-          { "name": "era", "value": "20th century" },
-          { "name": "theme", "value": "quotations" }
-        ]
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99,
-        "tags": [
-          { "name": "genre", "value": "fiction" },
-          { "name": "era", "value": "20th century" },
-          { "name": "theme", "value": "WWII" }
-        ]
-      },
-      {
-        "category": "fiction",
-        "author": "Herman Melville",
-        "title": "Moby Dick",
-        "isbn": "0-553-21311-3",
-        "price": 8.99,
-        "tags": [
-          { "name": "genre", "value": "fiction" },
-          { "name": "era", "value": "19th century" },
-          { "name": "theme", "value": "whale hunting" }
-        ]
-      },
-      {
-        "category": "fiction",
-        "author": "J. R. R. Tolkien",
-        "title": "The Lord of the Rings",
-        "isbn": "0-395-19395-8",
-        "price": 22.99,
-        "tags": [
-          { "name": "genre", "value": "fantasy" },
-          { "name": "era", "value": "20th century" },
-          { "name": "theme", "value": "good vs evil" }
-        ]
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  }
-}
-`
 
 func TestFind(t *testing.T) {
-	n, err := UnmarshalJSON([]byte(testStoreJSON))
+	n, err := UnmarshalJSON([]byte(testdata.StoreJSON))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -318,8 +318,6 @@ func Test_ParseQuery_Errors(t *testing.T) {
 	}
 }
 
-// NOTE: Copy from https://github.com/stedolan/jq/wiki/For-JSONPath-users#illustrative-object
-
 func TestFind(t *testing.T) {
 	n, err := UnmarshalJSON([]byte(testdata.StoreJSON))
 	if err != nil {

--- a/query_test.go
+++ b/query_test.go
@@ -491,25 +491,9 @@ func FuzzParseQuery(f *testing.F) {
 	})
 }
 
-const benchStoreJSON = `{
-  "store": {
-    "bicycle": { "color": "red", "price": 19.95 },
-    "book": [
-      { "author": "Nigel Rees", "category": "reference", "price": 8.95, "title": "Sayings of the Century",
-        "tags": [{"name":"genre","value":"reference"},{"name":"era","value":"20th century"},{"name":"theme","value":"quotations"}] },
-      { "author": "Evelyn Waugh", "category": "fiction", "price": 12.99, "title": "Sword of Honour",
-        "tags": [{"name":"genre","value":"fiction"},{"name":"era","value":"20th century"},{"name":"theme","value":"WWII"}] },
-      { "author": "Herman Melville", "category": "fiction", "isbn": "0-553-21311-3", "price": 8.99, "title": "Moby Dick",
-        "tags": [{"name":"genre","value":"fiction"},{"name":"era","value":"19th century"},{"name":"theme","value":"whale hunting"}] },
-      { "author": "J. R. R. Tolkien", "category": "fiction", "isbn": "0-395-19395-8", "price": 22.99, "title": "The Lord of the Rings",
-        "tags": [{"name":"genre","value":"fantasy"},{"name":"era","value":"20th century"},{"name":"theme","value":"good vs evil"}] }
-    ]
-  }
-}`
-
 func mustBenchNode(b *testing.B) Node {
 	b.Helper()
-	n, err := UnmarshalJSON([]byte(benchStoreJSON))
+	n, err := UnmarshalJSON([]byte(testdata.StoreJSON))
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- Move the \"Illustrative Object\" JSON fixture (bookstore document,
  adapted from the jq wiki) out of \`query_test.go\` and into a
  dedicated \`tree/internal/testdata\` package so tree and its
  subpackages can share a single source of the fixture.
- Retire \`benchStoreJSON\` — a nearly-identical compressed copy used
  only for benchmarks. \`mustBenchNode\` and \`BenchmarkUnmarshalJSON\`
  now load \`testdata.StoreJSON\` directly.
- Carry the jq-wiki attribution onto the new const's doc comment; the
  now-orphaned \`// NOTE\` in \`query_test.go\` is removed.

Internal package, so no change to the public API surface.

## Test plan

- [x] \`go test ./...\`
- [x] \`go test -bench BenchmarkEdit -benchtime 1x ./...\`
- [x] \`go test -bench BenchmarkUnmarshalJSON -benchtime 1x ./...\`