### PR TITLE
feat(schema): Add validation package for tree.Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Tree is a simple structure for dealing with dynamic or unknown JSON/YAML in Go.
   - [Query](#query)
   - [Built-in Methods](#built-in-methods)
 - [Edit](#edit)
+- [Schema](#schema)
 - [tq](#tq)
 - [Contributing](#contributing)
 - [Third-party library licenses](#third-party-library-licenses)
@@ -29,6 +30,7 @@ Tree is a simple structure for dealing with dynamic or unknown JSON/YAML in Go.
 - Syntax similar to Go standard and map and slice.
 - Find function can be specified the [Query](#query) expression with [built-in methods](#built-in-methods).
 - Edit function can be specified the [Edit](#edit) expression.
+- Validate tree.Node against query-keyed rule sets via the [schema](docs/schema.md) subpackage.
 - Bundled 'tq' that is a portable command-line JSON/YAML processor.
 
 ## Road to 1.0
@@ -377,6 +379,31 @@ func ExampleEdit() {
 	//   map[ID:1 Name:Blue]
 }
 ```
+
+## Schema
+
+The [schema](docs/schema.md) subpackage validates tree.Node structures
+against a set of rules keyed by tree queries. Each `(query, rule)`
+entry runs the rule on every matched node; errors from all rules are
+collected and joined.
+
+```go
+err := schema.Validate(doc, schema.QueryRules{
+    ".name": schema.Required(schema.String{}),
+    ".age":  schema.Int{Min: schema.Int64Ptr(0), Max: schema.Int64Ptr(150)},
+})
+```
+
+Rules can also be loaded from YAML or JSON:
+
+```yaml
+".name": { type: string, required: true }
+".age":  { type: int, min: 0, max: 150 }
+```
+
+See [docs/schema.md](docs/schema.md) for a topic index, or the
+[godoc](https://pkg.go.dev/github.com/mojatter/tree/schema) for the
+full reference.
 
 ## tq
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,406 @@
+# Schema
+
+The `schema` subpackage validates `tree.Node` structures against a
+set of rules keyed by tree queries.
+
+> **Roles**
+> [`schema/doc.go`](../schema/doc.go) (rendered on
+> [pkg.go.dev](https://pkg.go.dev/github.com/mojatter/tree/schema))
+> is the API overview and is always authoritative for type and
+> function signatures. This file is the *scenario guide*: nested
+> validation walkthroughs, YAML reference, custom-rule cookbooks,
+> and the fine print around filter queries and error handling.
+> If a code snippet here drifts from the godoc, fix the godoc first
+> and treat this file as the follow-up.
+
+## Table of contents
+
+- [What it does](#what-it-does)
+- [Getting started: flat rules](#getting-started-flat-rules)
+- [Nested validation with `Every`](#nested-validation-with-every)
+- [`"[]"` suffix vs `Every`](#-suffix-vs-every)
+- [Filter queries and where they fall short](#filter-queries-and-where-they-fall-short)
+- [Nil semantics](#nil-semantics)
+- [Loading rules from YAML / JSON](#loading-rules-from-yaml--json)
+- [Custom rule types](#custom-rule-types)
+- [Dispatching custom rules with `ValidateWithPrefix`](#dispatching-custom-rules-with-validatewithprefix)
+- [Error handling](#error-handling)
+- [Topic index (godoc jump-list)](#topic-index-godoc-jump-list)
+
+## What it does
+
+- Each `(query, rule)` entry in a [`QueryRules`][QueryRules] map is
+  applied to every tree node matched by the query.
+- [`schema.Validate(doc, rules)`][Validate] collects all rule errors
+  and joins them with `errors.Join`, so a single call surfaces every
+  violation.
+- A missing node is passed to the rule as `tree.Nil`; only
+  [`Require`][Require] fires on nil, which is what makes
+  [`schema.Required(r)`][Required] idiomatic for "must be present and
+  satisfy `r`".
+- The package is **not** JSON Schema compatible — the primitives are
+  standalone validation rules, and only the aggregate `QueryRules`
+  map behaves schema-like.
+
+## Getting started: flat rules
+
+A rule set says *what each value must be*, keyed by a tree query
+that picks the value. Here is a minimal rule set written as a YAML
+spec (the form most users reach for first):
+
+```yaml
+".name":   { type: string, required: true }
+".age":    { type: int, min: 0, max: 150 }
+".tags[]": { type: string }
+".":       { type: map, keys: [name, age, tags] }
+```
+
+Loading that spec into a usable rule set is covered in
+[Loading rules from YAML / JSON](#loading-rules-from-yaml--json) —
+short version: decode the YAML into a `tree.Node`, then pass it to
+`schema.ParseQueryRules`.
+
+The same rules as Go values, if you prefer to build them directly
+in code:
+
+```go
+doc := tree.Map{
+    "name": tree.V("alice"),
+    "age":  tree.V(30),
+    "tags": tree.A("ops", "oncall"),
+}
+err := schema.Validate(doc, schema.QueryRules{
+    ".name":   schema.Required(schema.String{}),
+    ".age":    schema.Int{Min: schema.Int64Ptr(0), Max: schema.Int64Ptr(150)},
+    ".tags[]": schema.String{},
+    ".":       schema.Map{Keys: []string{"name", "age", "tags"}},
+})
+```
+
+- `".tags[]"` expands matches; each non-string element surfaces at
+  `.tags[i]`.
+- `Map{Keys: ...}` is an allow-list on the root; any key outside the
+  list is reported as an error (sorted for stable output).
+
+[`IntPtr`][IntPtr], [`Int64Ptr`][Int64Ptr], and
+[`Float64Ptr`][Float64Ptr] exist so you can set `Min`/`Max` inline
+without a temporary variable.
+
+## Nested validation with `Every`
+
+When each element of an array or each value of a map needs its own
+set of rules, wrap a `QueryRules` set in [`Every`][Every]. The
+bookstore fixture from tree's README has a `.store.book` array where
+every book should carry an `isbn`, a non-negative `price`, and tags
+whose `value` is a non-empty string:
+
+```go
+rules := schema.QueryRules{
+    ".store.bicycle.color": schema.Required(schema.String{Enum: []string{"red", "blue", "green"}}),
+    ".store.book": schema.Every{Rules: schema.QueryRules{
+        ".isbn":  schema.Required(schema.String{}),
+        ".price": schema.Required(schema.Float{Min: schema.Float64Ptr(0)}),
+        ".tags":  schema.Every{Rules: schema.QueryRules{
+            ".value": schema.Required(schema.String{}),
+        }},
+    }},
+}
+err := schema.Validate(doc, rules)
+```
+
+Books missing an ISBN surface as `.store.book[0].isbn: required`.
+Each rule query inside an `Every` is resolved relative to the
+element, and error paths include the concrete index or key. `Every`
+can be nested arbitrarily deep — above, `.tags` is another `Every`
+inside the outer one.
+
+See [`ExampleValidate_nested`](../schema/example_test.go) for a
+runnable version of the full fixture.
+
+## `"[]"` suffix vs `Every`
+
+Both iterate over array elements or map values, but they differ in
+how they treat each element:
+
+| Feature | `"[]"` suffix | `Every` |
+| ------- | ------------- | ------- |
+| Applies leaf rule per element | ✓ | via inner rules |
+| Applies sub-rule set per element | — | ✓ |
+| `Required` fires per element | — (only on the parent) | ✓ |
+| Good for | `.arr[] = String{}` type checks | elements with required sub-fields |
+
+Use `"[]"` for cheap "every element must be type X" checks. Reach
+for `Every` the moment you need per-element `Required`, nested
+structure, or two or more rules per element.
+
+## Filter queries and where they fall short
+
+Filter-style queries like `.store.book[.category == "fiction"]` work
+— `tree.Find` returns the matching nodes and the rule runs on each —
+but with two caveats that make them a poor fit for most validation
+jobs:
+
+1. **Error paths stay as the filter expression.** If three matches
+   fail, all three errors carry the same display path (the whole
+   `.store.book[.category == "fiction"]` string). You cannot tell
+   which element failed.
+2. **Zero matches treat the filter as a single Nil node.** A
+   `Required` rule on a filter fires once with the filter itself as
+   the "missing" path, which is rarely the intent.
+
+Only a literal `"[]"` suffix triggers per-element expansion. When
+you want element-level error reporting, use `"[]"` or wrap the
+parent array/map in `Every`. Filter queries are great for the
+`tree.Find` side (selecting nodes to read) but clash with
+validation's need for attribution.
+
+## Nil semantics
+
+When a query yields no matches, the rule is invoked with `tree.Nil`:
+
+- Leaf rules (`String`, `Int`, `Float`, `Bool`, `Array`, `Map`) and
+  composites (`And`, `Or`, `Not`, `Every`) return nil on `Nil`. A
+  bare rule means "if present, satisfy this constraint".
+- Only [`Require`][Require] fires on `Nil`. Use
+  [`Required(r)`][Required] — which is `And{Require{}, r}` — to
+  make presence mandatory.
+- `Required` is idempotent: `Required(Required(r))` is the same as
+  `Required(r)`.
+
+## Loading rules from YAML / JSON
+
+[`ParseQueryRules`][ParseQueryRules] decodes a `tree.Node` —
+typically produced by a YAML or JSON decoder — into `QueryRules`.
+The document is a map where each key is a tree query and each value
+is a rule spec:
+
+```yaml
+".name":   { type: string, required: true }
+".age":    { type: int, min: 0, max: 150 }
+".tags[]": { type: string }
+".":       { type: map, keys: [name, age, tags] }
+```
+
+Each spec must carry a `type` field. `required: true` wraps the
+resulting rule with `Required`.
+
+### Built-in types and their fields
+
+| type | fields |
+| ---- | ------ |
+| `require` | *(none)* |
+| `string` | `enum`, `regex`, `minLen`, `maxLen` |
+| `int` | `min`, `max` |
+| `float` | `min`, `max` |
+| `bool` | *(none)* |
+| `array` | `minLen`, `maxLen` |
+| `map` | `keys` |
+| `and` | `of: [spec, ...]` |
+| `or` | `of: [spec, ...]` |
+| `not` | `rule: spec` |
+| `every` | `rules: {query: spec, ...}` |
+
+Plus the universal meta fields `type` and `required`. Unknown
+fields on a spec are rejected. Field types are checked strictly —
+for example, `min: "0"` is an error, not coerced to `0`.
+
+### Nested YAML example
+
+The bookstore rules from earlier, written as a spec:
+
+```yaml
+".store.bicycle.color": { type: string, required: true, enum: [red, blue, green] }
+".store.book":
+  type: every
+  rules:
+    ".isbn":  { type: string, required: true }
+    ".price": { type: float, required: true, min: 0 }
+    ".tags":
+      type: every
+      rules:
+        ".value": { type: string, required: true }
+```
+
+Leaf specs go on one line in flow style for density; specs with
+nested content (here, `every.rules`) stay in block style so the
+nesting is readable. `every.rules` recurses, so any of the
+built-in or custom types can appear at any level.
+
+## Custom rule types
+
+Any Go value implementing [`Rule`][Rule] can be dropped into a
+`QueryRules` map:
+
+```go
+type UUID struct{}
+
+func (UUID) Validate(n tree.Node, q string) error {
+    if n.IsNil() {
+        return nil
+    }
+    if !n.Type().IsStringValue() {
+        return fmt.Errorf("%s: expected string, got %s", q, n.Type())
+    }
+    // ... real UUID parsing ...
+    return nil
+}
+
+rules := schema.QueryRules{".id": schema.Required(UUID{})}
+```
+
+Conventions to keep custom rules predictable alongside the built-in
+ones:
+
+- Return nil on `Nil`; wrapping with `Required` is the caller's job.
+- Use the passed-in `q` (query path) as the error prefix so error
+  paths line up with the rest of the package.
+- Collect all sub-errors and `errors.Join` them rather than
+  short-circuiting on the first failure.
+
+### Registering a custom type for the YAML / JSON loader
+
+To expose a custom rule to [`ParseQueryRulesWith`][ParseQueryRulesWith],
+register a factory with a [`Registry`][Registry]:
+
+```go
+reg := schema.BuiltinRegistry()
+reg.Register("uuid", parseUUIDSpec, "version")
+rules, err := schema.ParseQueryRulesWith(specNode, reg)
+```
+
+The `fields` argument declares which spec keys the factory consumes
+beyond the universal `type` and `required`. Any other key on the
+spec is reported as an unknown-field error — this keeps typos from
+silently passing.
+
+## Dispatching custom rules with `ValidateWithPrefix`
+
+Some configurations use a discriminator field to pick a sub-schema —
+for example, a `handlers` map where each value has `type: http`,
+`type: file`, or another handler kind, each with its own required
+fields. The clean way to validate that in this package is a custom
+rule that looks at the discriminator and calls
+[`ValidateWithPrefix`][ValidateWithPrefix] on a pre-built
+`QueryRules` set for the chosen kind:
+
+```go
+type HandlerDispatch struct {
+    ByType map[string]schema.QueryRules
+}
+
+func (r HandlerDispatch) Validate(n tree.Node, q string) error {
+    if n.IsNil() {
+        return nil
+    }
+    typ := n.Get("type").Value().String()
+    sub, ok := r.ByType[typ]
+    if !ok {
+        return nil // or flag unknown type, up to the caller
+    }
+    return schema.ValidateWithPrefix(n, sub, q)
+}
+```
+
+Combined with a top-level `Every` over the handlers map:
+
+```go
+rules := schema.QueryRules{
+    ".handlers": schema.Every{Rules: schema.QueryRules{
+        ".": HandlerDispatch{ByType: map[string]schema.QueryRules{
+            "http": {".port": schema.Required(schema.Int{})},
+            "file": {".path": schema.Required(schema.String{})},
+        }},
+    }},
+}
+```
+
+Errors from a handler missing its required field surface as, e.g.,
+`.handlers["c"].port: required` — the enclosing map-key is preserved
+in the path because `ValidateWithPrefix` prepended it.
+
+Without `ValidateWithPrefix`, the custom rule would have to unwrap
+the inner errors and re-wrap them with `fmt.Errorf("%s: %w", q, ...)`
+by hand, which is easy to get wrong (especially for multi-error
+joins). Prefer `ValidateWithPrefix` in any composite rule that
+re-applies a `QueryRules` set to a subtree.
+
+## Error handling
+
+`Validate`, `ParseQueryRules`, and `Registry.Parse` collect errors
+via `errors.Join`, so every violation is surfaced in a single call.
+`Registry.MaxReportedErrors` caps the number of parsed-spec errors
+(default 20); overflow is summarised as `"and N more errors"`.
+`Validate` itself currently has no such cap — the number of
+violations scales with the data.
+
+### `*ErrQuery` — malformed rule queries
+
+A malformed rule query (one that `tree.Find` rejects) is a bug in
+the rules definition, not a data violation. `Validate` and
+`ValidateWithPrefix` fail fast on that case and return a single
+[`*ErrQuery`][ErrQuery] without joining any data-level violations:
+
+```go
+err := schema.Validate(doc, schema.QueryRules{
+    ".name": schema.String{},
+    ".bad[": schema.String{}, // syntax error in the rule query
+})
+var eq *schema.ErrQuery
+if errors.As(err, &eq) {
+    // The rules are broken. eq.Query is the failing path
+    // (already prefixed if the rule ran inside Every or
+    // ValidateWithPrefix); eq.Err wraps the underlying
+    // tree.Find error.
+}
+```
+
+Why fail fast? A broken rule query means every subsequent invocation
+of the same rule set would emit the same error; joining it with
+unrelated data violations would only produce noise. Fix the rule,
+rerun, get a clean picture of what the data itself actually
+violates.
+
+## Topic index (godoc jump-list)
+
+Quick links into the [godoc][pkg] for readers who want the API
+reference alongside this guide.
+
+- **Core:** [`Validate`][Validate], [`ValidateWithPrefix`][ValidateWithPrefix],
+  [`QueryRules`][QueryRules], [`Rule`][Rule].
+- **Presence / composition:** [`Require`][Require],
+  [`Required`][Required], [`And`][And], [`Or`][Or], [`Not`][Not],
+  [`Every`][Every].
+- **Leaf rules:** [`String`][String], [`Int`][Int], [`Float`][Float],
+  [`Bool`][Bool], [`Array`][Array], [`Map`][Map].
+- **Helpers:** [`IntPtr`][IntPtr], [`Int64Ptr`][Int64Ptr],
+  [`Float64Ptr`][Float64Ptr].
+- **YAML / JSON loader:** [`ParseQueryRules`][ParseQueryRules],
+  [`ParseQueryRulesWith`][ParseQueryRulesWith],
+  [`BuiltinRegistry`][BuiltinRegistry], [`Registry`][Registry].
+- **Errors:** [`*ErrQuery`][ErrQuery].
+
+[pkg]: https://pkg.go.dev/github.com/mojatter/tree/schema
+[Validate]: https://pkg.go.dev/github.com/mojatter/tree/schema#Validate
+[ValidateWithPrefix]: https://pkg.go.dev/github.com/mojatter/tree/schema#ValidateWithPrefix
+[QueryRules]: https://pkg.go.dev/github.com/mojatter/tree/schema#QueryRules
+[Rule]: https://pkg.go.dev/github.com/mojatter/tree/schema#Rule
+[Require]: https://pkg.go.dev/github.com/mojatter/tree/schema#Require
+[Required]: https://pkg.go.dev/github.com/mojatter/tree/schema#Required
+[And]: https://pkg.go.dev/github.com/mojatter/tree/schema#And
+[Or]: https://pkg.go.dev/github.com/mojatter/tree/schema#Or
+[Not]: https://pkg.go.dev/github.com/mojatter/tree/schema#Not
+[Every]: https://pkg.go.dev/github.com/mojatter/tree/schema#Every
+[String]: https://pkg.go.dev/github.com/mojatter/tree/schema#String
+[Int]: https://pkg.go.dev/github.com/mojatter/tree/schema#Int
+[Float]: https://pkg.go.dev/github.com/mojatter/tree/schema#Float
+[Bool]: https://pkg.go.dev/github.com/mojatter/tree/schema#Bool
+[Array]: https://pkg.go.dev/github.com/mojatter/tree/schema#Array
+[Map]: https://pkg.go.dev/github.com/mojatter/tree/schema#Map
+[IntPtr]: https://pkg.go.dev/github.com/mojatter/tree/schema#IntPtr
+[Int64Ptr]: https://pkg.go.dev/github.com/mojatter/tree/schema#Int64Ptr
+[Float64Ptr]: https://pkg.go.dev/github.com/mojatter/tree/schema#Float64Ptr
+[ParseQueryRules]: https://pkg.go.dev/github.com/mojatter/tree/schema#ParseQueryRules
+[ParseQueryRulesWith]: https://pkg.go.dev/github.com/mojatter/tree/schema#ParseQueryRulesWith
+[BuiltinRegistry]: https://pkg.go.dev/github.com/mojatter/tree/schema#BuiltinRegistry
+[Registry]: https://pkg.go.dev/github.com/mojatter/tree/schema#Registry
+[ErrQuery]: https://pkg.go.dev/github.com/mojatter/tree/schema#ErrQuery

--- a/schema/doc.go
+++ b/schema/doc.go
@@ -1,0 +1,171 @@
+// Package schema validates [github.com/mojatter/tree.Node] structures
+// against a set of rules keyed by tree queries. Each (query, [Rule])
+// entry applies the rule to every node matched by the query.
+//
+// The package is not JSON Schema compatible; individual primitives
+// ([Require], [String], and so on) are validation rules rather than
+// full schema documents. The collective form [QueryRules] behaves
+// schema-like as a whole.
+//
+// # Programmatic usage
+//
+// Rules are ordinary Go values and can be composed directly. A flat
+// document validates with a flat set of rules:
+//
+//	rules := schema.QueryRules{
+//	    ".name":    schema.Required(schema.String{}),
+//	    ".age":     schema.Int{Min: schema.Int64Ptr(0), Max: schema.Int64Ptr(150)},
+//	    ".tags[]":  schema.String{},
+//	    ".":        schema.Map{Keys: []string{"name", "age", "tags"}},
+//	}
+//	err := schema.Validate(doc, rules)
+//
+// Deeper trees mix dot-paths with [Every] to apply rules to each
+// element of an array or each value of a map. Take tree's standard
+// "Illustrative Object" fixture (a bookstore document shaped like
+// {store: {book: [{isbn, price, tags: [{name, value}, ...]}, ...],
+// bicycle: {color, price}}}):
+//
+//	rules := schema.QueryRules{
+//	    ".store.bicycle.color": schema.Required(schema.String{Enum: []string{"red", "blue", "green"}}),
+//	    ".store.book": schema.Every{Rules: schema.QueryRules{
+//	        ".isbn":  schema.Required(schema.String{}),
+//	        ".price": schema.Required(schema.Float{Min: schema.Float64Ptr(0)}),
+//	        ".tags":  schema.Every{Rules: schema.QueryRules{
+//	            ".value": schema.Required(schema.String{}),
+//	        }},
+//	    }},
+//	}
+//
+// Inside [Every], each query is resolved relative to the element,
+// so a book missing ".isbn" surfaces as ".store.book[0].isbn:
+// required" rather than being silently absent. Every can be nested
+// arbitrarily deep — here ".tags" is another Every inside the outer
+// one, so per-tag ".value" is checked with the full element path.
+//
+// Array and map iteration use the tree query "[]" suffix. The error
+// path for each element carries the concrete index ("[0]", "[1]", ...)
+// for arrays and the concrete key (`["admin"]`, `["guest"]`, ...) for
+// maps. When the base of "[]" resolves to more than one parent,
+// numeric indices are used as a fallback.
+//
+// Only a literal "[]" suffix triggers this per-element expansion.
+// Filter queries like ".arr[.age > 18]" still work — tree.Find returns
+// the matching nodes and the rule runs on each — but the error path
+// stays verbatim as the whole filter expression, so multiple failing
+// matches share one display path and cannot be told apart. A filter
+// that matches zero nodes also makes [Required] fire once on that
+// filter, which is rarely the intent. Use "[]" (or wrap the parent
+// array/map in [Every]) when element-level error paths or
+// required-per-element semantics are needed.
+//
+// # Nil semantics
+//
+// When a query matches no node, the rule is invoked with
+// [github.com/mojatter/tree.Nil]. Leaf rules ([String], [Int], [Float],
+// [Bool], [Array], [Map]) and composites ([And], [Or], [Not], [Every])
+// return nil on Nil, so a bare rule means "if present, satisfy this
+// constraint". Only [Require] fires on Nil. Wrap a rule with
+// [Required] (or prepend [Require] via [And]) to make the presence
+// mandatory.
+//
+// # Rule types
+//
+//   - [Require]: fires when the node is Nil.
+//   - [And]: passes when every child rule passes; collects all errors.
+//   - [Or]: passes when at least one child rule passes.
+//   - [Not]: passes when the inner rule fails; skips Nil.
+//   - [Every]: applies a QueryRules set to each element of an array
+//     or each value of a map. Required rules inside Every fire
+//     per element, unlike a bare "[]"-suffixed query which flattens
+//     matches and cannot detect a missing sub-field on a specific
+//     element.
+//   - [String]: a string leaf with optional Enum, Regex, and length bounds.
+//   - [Int]: an integer-valued number with optional bounds; rejects NaN,
+//     Inf, fractional values, and values outside int64 range.
+//   - [Float]: a number leaf with optional float bounds; rejects NaN.
+//   - [Bool]: a boolean leaf.
+//   - [Array]: an array with optional length bounds. Element-level
+//     rules are expressed as separate entries on a "[]"-suffixed query.
+//   - [Map]: a map with optional Keys allow-list.
+//
+// # YAML / JSON format
+//
+// [ParseQueryRules] decodes a tree.Node (typically produced by yaml
+// or json decoders) into [QueryRules]. The document is a map where
+// each key is a tree query and each value is a rule spec.
+//
+// A rule spec is a map carrying at least a "type" field; the factory
+// registered for that type consumes the rest. The meta-flag
+// "required: true" wraps the resulting rule with [Required].
+//
+// The built-in registry ([BuiltinRegistry]) recognises these types:
+//
+//	type      | fields
+//	---------------------------------------------------------------
+//	require   | (none)
+//	string    | enum, regex, minLen, maxLen
+//	int       | min, max
+//	float     | min, max
+//	bool      | (none)
+//	array     | minLen, maxLen
+//	map       | keys
+//	and       | of: [spec...]
+//	or        | of: [spec...]
+//	not       | rule: spec
+//	every     | rules: {query: spec, ...}
+//
+// Plus the universal meta fields "type" and "required".
+//
+// Example YAML (decoded into a tree.Map and passed to
+// [ParseQueryRules]). The shape mirrors the nested programmatic
+// example above:
+//
+//	".store.bicycle.color":
+//	  type: string
+//	  required: true
+//	  enum: [red, blue, green]
+//	".store.book":
+//	  type: every
+//	  rules:
+//	    ".isbn":  { type: string, required: true }
+//	    ".price": { type: float, required: true, min: 0 }
+//	    ".tags":
+//	      type: every
+//	      rules:
+//	        ".value": { type: string, required: true }
+//
+// Unknown fields on a rule spec are rejected. "required" must be a
+// bool. Field types are enforced strictly (for example, "min: \"0\""
+// is an error).
+//
+// # Custom rule types
+//
+// User code can implement [Rule] directly and insert it into a
+// [QueryRules] map. To expose a custom rule to the YAML / JSON
+// loader, register a [Factory] with a [Registry]:
+//
+//	reg := schema.BuiltinRegistry()
+//	reg.Register("uuid", parseUUIDSpec, "version")
+//	rules, err := schema.ParseQueryRulesWith(specNode, reg)
+//
+// The factory's fields argument declares which type-specific keys the
+// spec may carry (beyond "type" and "required"). Any other key on the
+// spec is reported as an unknown-field error.
+//
+// # Error aggregation
+//
+// [Validate], [ParseQueryRules], and [Registry.Parse] collect errors
+// via [errors.Join] so every violation is surfaced in one call.
+// [Registry.MaxReportedErrors] caps the number of parsed-spec errors
+// (default 20); overflow is summarised as "and N more errors".
+// [Validate] currently has no cap.
+//
+// One exception: when a rule's query string itself is malformed
+// (tree.Find rejects it), [Validate] and [ValidateWithPrefix] fail
+// fast and return a single [*ErrQuery] without joining any
+// data-level violations. A malformed query is a bug in the rules
+// definition rather than in the data, so emitting it alongside
+// unrelated violations would be noise. Callers that need to
+// distinguish the two can errors.As into [*ErrQuery].
+package schema

--- a/schema/doc.go
+++ b/schema/doc.go
@@ -1,171 +1,89 @@
 // Package schema validates [github.com/mojatter/tree.Node] structures
 // against a set of rules keyed by tree queries. Each (query, [Rule])
-// entry applies the rule to every node matched by the query.
+// entry applies the rule to every node matched by the query; [Validate]
+// joins all violations via errors.Join so one call surfaces every
+// failure.
 //
-// The package is not JSON Schema compatible; individual primitives
-// ([Require], [String], and so on) are validation rules rather than
-// full schema documents. The collective form [QueryRules] behaves
-// schema-like as a whole.
+// This comment is an API overview. Extended scenarios — the nested
+// bookstore example, the filter-query caveat, the full YAML spec
+// reference, dispatch-style custom rules using [ValidateWithPrefix],
+// and [*ErrQuery] handling — live in docs/schema.md on GitHub:
+// https://github.com/mojatter/tree/blob/main/docs/schema.md
 //
-// # Programmatic usage
+// # Mental model
 //
-// Rules are ordinary Go values and can be composed directly. A flat
-// document validates with a flat set of rules:
+//   - [QueryRules] is a map from a tree query to the [Rule] applied
+//     at every match.
+//   - A missing node is passed to the rule as
+//     [github.com/mojatter/tree.Nil]; only [Require] fires on Nil, so
+//     [Required] (= And{Require{}, r}) is the idiomatic "must be
+//     present and satisfy r".
+//   - A rule query ending in "[]" expands matches: errors carry the
+//     concrete index (.arr[i]) for arrays and the concrete key
+//     (.obj["k"]) for maps.
+//   - Only a literal "[]" suffix triggers element expansion. Filter
+//     queries like ".arr[.age > 18]" still run but attribute all
+//     failures to the filter expression itself; see docs/schema.md
+//     for the workaround.
 //
 //	rules := schema.QueryRules{
-//	    ".name":    schema.Required(schema.String{}),
-//	    ".age":     schema.Int{Min: schema.Int64Ptr(0), Max: schema.Int64Ptr(150)},
-//	    ".tags[]":  schema.String{},
-//	    ".":        schema.Map{Keys: []string{"name", "age", "tags"}},
+//	    ".name": schema.Required(schema.String{}),
+//	    ".age":  schema.Int{Min: schema.Int64Ptr(0), Max: schema.Int64Ptr(150)},
 //	}
 //	err := schema.Validate(doc, rules)
-//
-// Deeper trees mix dot-paths with [Every] to apply rules to each
-// element of an array or each value of a map. Take tree's standard
-// "Illustrative Object" fixture (a bookstore document shaped like
-// {store: {book: [{isbn, price, tags: [{name, value}, ...]}, ...],
-// bicycle: {color, price}}}):
-//
-//	rules := schema.QueryRules{
-//	    ".store.bicycle.color": schema.Required(schema.String{Enum: []string{"red", "blue", "green"}}),
-//	    ".store.book": schema.Every{Rules: schema.QueryRules{
-//	        ".isbn":  schema.Required(schema.String{}),
-//	        ".price": schema.Required(schema.Float{Min: schema.Float64Ptr(0)}),
-//	        ".tags":  schema.Every{Rules: schema.QueryRules{
-//	            ".value": schema.Required(schema.String{}),
-//	        }},
-//	    }},
-//	}
-//
-// Inside [Every], each query is resolved relative to the element,
-// so a book missing ".isbn" surfaces as ".store.book[0].isbn:
-// required" rather than being silently absent. Every can be nested
-// arbitrarily deep — here ".tags" is another Every inside the outer
-// one, so per-tag ".value" is checked with the full element path.
-//
-// Array and map iteration use the tree query "[]" suffix. The error
-// path for each element carries the concrete index ("[0]", "[1]", ...)
-// for arrays and the concrete key (`["admin"]`, `["guest"]`, ...) for
-// maps. When the base of "[]" resolves to more than one parent,
-// numeric indices are used as a fallback.
-//
-// Only a literal "[]" suffix triggers this per-element expansion.
-// Filter queries like ".arr[.age > 18]" still work — tree.Find returns
-// the matching nodes and the rule runs on each — but the error path
-// stays verbatim as the whole filter expression, so multiple failing
-// matches share one display path and cannot be told apart. A filter
-// that matches zero nodes also makes [Required] fire once on that
-// filter, which is rarely the intent. Use "[]" (or wrap the parent
-// array/map in [Every]) when element-level error paths or
-// required-per-element semantics are needed.
-//
-// # Nil semantics
-//
-// When a query matches no node, the rule is invoked with
-// [github.com/mojatter/tree.Nil]. Leaf rules ([String], [Int], [Float],
-// [Bool], [Array], [Map]) and composites ([And], [Or], [Not], [Every])
-// return nil on Nil, so a bare rule means "if present, satisfy this
-// constraint". Only [Require] fires on Nil. Wrap a rule with
-// [Required] (or prepend [Require] via [And]) to make the presence
-// mandatory.
 //
 // # Rule types
 //
 //   - [Require]: fires when the node is Nil.
-//   - [And]: passes when every child rule passes; collects all errors.
-//   - [Or]: passes when at least one child rule passes.
+//   - [And]: passes when every child passes; collects all errors.
+//   - [Or]: passes when at least one child passes.
 //   - [Not]: passes when the inner rule fails; skips Nil.
-//   - [Every]: applies a QueryRules set to each element of an array
-//     or each value of a map. Required rules inside Every fire
-//     per element, unlike a bare "[]"-suffixed query which flattens
-//     matches and cannot detect a missing sub-field on a specific
-//     element.
-//   - [String]: a string leaf with optional Enum, Regex, and length bounds.
-//   - [Int]: an integer-valued number with optional bounds; rejects NaN,
-//     Inf, fractional values, and values outside int64 range.
-//   - [Float]: a number leaf with optional float bounds; rejects NaN.
-//   - [Bool]: a boolean leaf.
-//   - [Array]: an array with optional length bounds. Element-level
-//     rules are expressed as separate entries on a "[]"-suffixed query.
-//   - [Map]: a map with optional Keys allow-list.
+//   - [Every]: apply a QueryRules set to each element of an array or
+//     each value of a map. Required inside Every fires per element,
+//     which a bare "[]"-suffixed query cannot do.
+//   - [String]: string leaf with optional Enum, Regex, MinLen, MaxLen.
+//   - [Int]: integer-valued number with optional Min/Max; rejects NaN,
+//     Inf, fractional, and out-of-int64-range values.
+//   - [Float]: number leaf with optional Min/Max; rejects NaN.
+//   - [Bool]: boolean leaf.
+//   - [Array]: array leaf with optional MinLen/MaxLen. Element rules
+//     go on separate "[]"-suffixed queries.
+//   - [Map]: map leaf with optional Keys allow-list.
 //
-// # YAML / JSON format
+// [IntPtr], [Int64Ptr], and [Float64Ptr] let you set Min/Max inline
+// without a temporary variable.
 //
-// [ParseQueryRules] decodes a tree.Node (typically produced by yaml
-// or json decoders) into [QueryRules]. The document is a map where
-// each key is a tree query and each value is a rule spec.
+// # YAML / JSON rule specs
 //
-// A rule spec is a map carrying at least a "type" field; the factory
-// registered for that type consumes the rest. The meta-flag
-// "required: true" wraps the resulting rule with [Required].
-//
-// The built-in registry ([BuiltinRegistry]) recognises these types:
-//
-//	type      | fields
-//	---------------------------------------------------------------
-//	require   | (none)
-//	string    | enum, regex, minLen, maxLen
-//	int       | min, max
-//	float     | min, max
-//	bool      | (none)
-//	array     | minLen, maxLen
-//	map       | keys
-//	and       | of: [spec...]
-//	or        | of: [spec...]
-//	not       | rule: spec
-//	every     | rules: {query: spec, ...}
-//
-// Plus the universal meta fields "type" and "required".
-//
-// Example YAML (decoded into a tree.Map and passed to
-// [ParseQueryRules]). The shape mirrors the nested programmatic
-// example above:
-//
-//	".store.bicycle.color":
-//	  type: string
-//	  required: true
-//	  enum: [red, blue, green]
-//	".store.book":
-//	  type: every
-//	  rules:
-//	    ".isbn":  { type: string, required: true }
-//	    ".price": { type: float, required: true, min: 0 }
-//	    ".tags":
-//	      type: every
-//	      rules:
-//	        ".value": { type: string, required: true }
-//
-// Unknown fields on a rule spec are rejected. "required" must be a
-// bool. Field types are enforced strictly (for example, "min: \"0\""
-// is an error).
+// [ParseQueryRules] decodes a tree.Node (typically produced by a YAML
+// or JSON decoder) into [QueryRules]. Every spec carries a "type"
+// field and an optional meta flag "required: true". The built-in
+// types, their fields, and nested spec examples are in
+// docs/schema.md.
 //
 // # Custom rule types
 //
-// User code can implement [Rule] directly and insert it into a
-// [QueryRules] map. To expose a custom rule to the YAML / JSON
-// loader, register a [Factory] with a [Registry]:
+// Any Go value implementing [Rule] can be inserted into a QueryRules
+// map. To expose a custom rule to the YAML / JSON loader, register a
+// [Factory] with a [Registry]:
 //
 //	reg := schema.BuiltinRegistry()
 //	reg.Register("uuid", parseUUIDSpec, "version")
 //	rules, err := schema.ParseQueryRulesWith(specNode, reg)
 //
-// The factory's fields argument declares which type-specific keys the
-// spec may carry (beyond "type" and "required"). Any other key on the
-// spec is reported as an unknown-field error.
+// [ValidateWithPrefix] helps composite custom rules re-apply a
+// QueryRules set to a subtree and attribute sub-errors to the
+// enclosing location. docs/schema.md walks through a
+// dispatch-on-"type" cookbook.
 //
-// # Error aggregation
+// # Errors
 //
-// [Validate], [ParseQueryRules], and [Registry.Parse] collect errors
-// via [errors.Join] so every violation is surfaced in one call.
-// [Registry.MaxReportedErrors] caps the number of parsed-spec errors
-// (default 20); overflow is summarised as "and N more errors".
-// [Validate] currently has no cap.
+// [Validate], [ParseQueryRules], and [Registry.Parse] join violations
+// via errors.Join. [Registry.MaxReportedErrors] caps parsed-spec
+// errors (default 20); overflow is summarised as "and N more errors".
 //
-// One exception: when a rule's query string itself is malformed
-// (tree.Find rejects it), [Validate] and [ValidateWithPrefix] fail
-// fast and return a single [*ErrQuery] without joining any
-// data-level violations. A malformed query is a bug in the rules
-// definition rather than in the data, so emitting it alongside
-// unrelated violations would be noise. Callers that need to
-// distinguish the two can errors.As into [*ErrQuery].
+// A malformed rule query — a bug in the rules, not the data — causes
+// [Validate] and [ValidateWithPrefix] to fail fast and return a single
+// [*ErrQuery] without joining any data-level violations. Callers that
+// need to distinguish can errors.As into [*ErrQuery].
 package schema

--- a/schema/example_test.go
+++ b/schema/example_test.go
@@ -1,0 +1,143 @@
+package schema_test
+
+import (
+	"fmt"
+
+	"github.com/mojatter/tree"
+	"github.com/mojatter/tree/internal/testdata"
+	"github.com/mojatter/tree/schema"
+)
+
+// Validate walks the document once per rule and aggregates every
+// violation via errors.Join. The example shows a document that breaks
+// four rules; all of them surface in a single error value.
+func ExampleValidate() {
+	doc := tree.Map{
+		"name": tree.V("alice"),
+		"age":  tree.V(-1),
+		"tags": tree.A("ok", 1),
+		"role": tree.V("guest"),
+	}
+	rules := schema.QueryRules{
+		".name":   schema.Required(schema.String{}),
+		".age":    schema.Int{Min: schema.Int64Ptr(0)},
+		".tags[]": schema.String{},
+		".role":   schema.String{Enum: []string{"admin", "user"}},
+	}
+	if err := schema.Validate(doc, rules); err != nil {
+		fmt.Println(err)
+	}
+	// Output:
+	// .age: value -1 less than min 0
+	// .role: value "guest" not in enum [admin user]
+	// .tags[1]: expected string, got number
+}
+
+// ExampleValidate_composite shows less-common patterns: Or for a
+// polymorphic field, Not wrapping a String.Enum as a blocklist,
+// per-field rules inside a nested map (`.labels.env` /
+// `.labels.tier`), a Map rule at the root asserting the allowed
+// key set, and Every applying per-element rules so Required fires
+// on elements that are missing a sub-field.
+func ExampleValidate_composite() {
+	doc := tree.Map{
+		"password": tree.V("12345"),
+		"allow":    tree.V(42),
+		"labels": tree.Map{
+			"env":  tree.V("prod"),
+			"tier": tree.V("one"), // should be number
+		},
+		"tags": tree.A(
+			tree.Map{"name": tree.V("prod"), "count": tree.V(1)},
+			tree.Map{"count": tree.V(2)}, // missing "name"
+		),
+	}
+	rules := schema.QueryRules{
+		".": schema.Map{Keys: []string{"password", "allow", "labels", "tags"}},
+		".password": schema.And{
+			schema.Required(schema.String{MinLen: schema.IntPtr(8)}),
+			schema.Not{Rule: schema.String{Enum: []string{"password", "12345678"}}},
+		},
+		".allow":       schema.Or{schema.String{}, schema.Bool{}},
+		".labels.env":  schema.String{},
+		".labels.tier": schema.Int{},
+		".tags": schema.Every{Rules: schema.QueryRules{
+			".name": schema.Required(schema.String{}),
+		}},
+	}
+	if err := schema.Validate(doc, rules); err != nil {
+		fmt.Println(err)
+	}
+	// Output:
+	// .allow: expected string, got number
+	// .allow: expected bool, got number
+	// .labels.tier: expected number, got string
+	// .password: length 5 less than min 8
+	// .tags[1].name: required
+}
+
+// ExampleValidate_nested validates tree's "Illustrative Object"
+// fixture (a bookstore document with nested arrays and maps),
+// showing Every wrapped inside Every so Required fires per element
+// at arbitrary depth. The rules require every book to carry an
+// isbn and every tag to carry a value; books that are missing
+// isbn surface with the concrete index in the path.
+func ExampleValidate_nested() {
+	n, err := tree.UnmarshalJSON([]byte(testdata.StoreJSON))
+	if err != nil {
+		fmt.Println("unmarshal:", err)
+		return
+	}
+	rules := schema.QueryRules{
+		".store.bicycle.color": schema.Required(schema.String{Enum: []string{"red", "blue", "green"}}),
+		".store.book": schema.Every{Rules: schema.QueryRules{
+			".isbn":  schema.Required(schema.String{}),
+			".price": schema.Required(schema.Float{Min: schema.Float64Ptr(0)}),
+			".tags": schema.Every{Rules: schema.QueryRules{
+				".value": schema.Required(schema.String{}),
+			}},
+		}},
+	}
+	if err := schema.Validate(n, rules); err != nil {
+		fmt.Println(err)
+	}
+	// Output:
+	// .store.book[0].isbn: required
+	// .store.book[1].isbn: required
+}
+
+// ParseQueryRules decodes a tree.Node (here built directly, but
+// normally produced by a yaml or json decoder) into QueryRules.
+// Each entry's spec has a mandatory "type" field; "required: true"
+// wraps the rule with Required.
+func ExampleParseQueryRules() {
+	spec := tree.Map{
+		".name": tree.Map{"type": tree.V("string"), "required": tree.V(true)},
+		".age":  tree.Map{"type": tree.V("int"), "min": tree.V(0), "max": tree.V(150)},
+		".role": tree.Map{
+			"type": tree.V("or"),
+			"of": tree.A(
+				tree.Map{"type": tree.V("string"), "enum": tree.A("admin", "user")},
+				tree.Map{"type": tree.V("bool")},
+			),
+		},
+	}
+	rules, err := schema.ParseQueryRules(spec)
+	if err != nil {
+		fmt.Println("parse:", err)
+		return
+	}
+
+	doc := tree.Map{
+		"age":  tree.V(200),
+		"role": tree.V("guest"),
+	}
+	if err := schema.Validate(doc, rules); err != nil {
+		fmt.Println(err)
+	}
+	// Output:
+	// .age: value 200 greater than max 150
+	// .name: required
+	// .role: value "guest" not in enum [admin user]
+	// .role: expected bool, got string
+}

--- a/schema/registry.go
+++ b/schema/registry.go
@@ -1,0 +1,409 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+
+	"github.com/mojatter/tree"
+)
+
+// Factory parses a rule-specification node (a tree.Map typically
+// decoded from YAML or JSON) into a Rule. It receives the enclosing
+// Registry so composite factories (And, Or, Not) can recurse into
+// child specs.
+type Factory func(spec tree.Node, reg *Registry) (Rule, error)
+
+// Registry is a type-name -> Factory dispatch table. ParseQueryRules
+// looks up the "type" field on each spec and invokes the corresponding
+// Factory. Custom rule types are added via Register; use
+// BuiltinRegistry() to start with the built-in set.
+//
+// MaxReportedErrors caps the number of errors surfaced by Parse and
+// ParseQueryRulesWith; overflow is summarised as "and N more errors".
+// Zero or negative means no cap.
+type Registry struct {
+	entries           map[string]entry
+	MaxReportedErrors int
+}
+
+// entry bundles a factory with the list of type-specific fields it
+// accepts. Registry.Parse uses fields to reject unknown keys on the
+// spec ("type" and "required" are always implicitly accepted).
+type entry struct {
+	factory Factory
+	fields  []string
+}
+
+// NewRegistry returns an empty Registry with MaxReportedErrors = 20.
+// Use BuiltinRegistry() if you want the standard rule types
+// preinstalled.
+func NewRegistry() *Registry {
+	return &Registry{
+		entries:           map[string]entry{},
+		MaxReportedErrors: 20,
+	}
+}
+
+// BuiltinRegistry returns a Registry preloaded with the built-in rule
+// types: require, string, int, float, bool, array, map, and, or,
+// not, every.
+func BuiltinRegistry() *Registry {
+	r := NewRegistry()
+	r.Register("require", parseRequireSpec)
+	r.Register("string", parseStringSpec, "enum", "regex", "minLen", "maxLen")
+	r.Register("int", parseIntSpec, "min", "max")
+	r.Register("float", parseFloatSpec, "min", "max")
+	r.Register("bool", parseBoolSpec)
+	r.Register("array", parseArraySpec, "minLen", "maxLen")
+	r.Register("map", parseMapSpec, "keys")
+	r.Register("and", parseAndSpec, "of")
+	r.Register("or", parseOrSpec, "of")
+	r.Register("not", parseNotSpec, "rule")
+	r.Register("every", parseEverySpec, "rules")
+	return r
+}
+
+// Register adds or replaces the factory for name. fields lists the
+// type-specific field names accepted on the spec; "type" and
+// "required" are always accepted implicitly.
+func (r *Registry) Register(name string, fac Factory, fields ...string) {
+	r.entries[name] = entry{factory: fac, fields: fields}
+}
+
+// Parse dispatches spec to the factory registered under spec's "type"
+// field and returns the resulting Rule. Unknown fields are reported
+// as errors. When spec carries "required: true", the result is wrapped
+// with Required(...).
+func (r *Registry) Parse(spec tree.Node) (Rule, error) {
+	if !spec.Type().IsMap() {
+		return nil, fmt.Errorf("rule spec must be map, got %s", spec.Type())
+	}
+	m := spec.Map()
+
+	tn := m.Get("type")
+	if tn.IsNil() {
+		return nil, fmt.Errorf("rule spec missing 'type'")
+	}
+	if !tn.Type().IsStringValue() {
+		return nil, fmt.Errorf("'type' must be string, got %s", tn.Type())
+	}
+	typ := tn.Value().String()
+	if typ == "" {
+		return nil, fmt.Errorf("'type' must not be empty")
+	}
+
+	e, ok := r.entries[typ]
+	if !ok {
+		return nil, fmt.Errorf("unknown rule type %q", typ)
+	}
+
+	var errs []error
+
+	for _, k := range m.Keys() {
+		if k == "type" || k == "required" {
+			continue
+		}
+		if !slices.Contains(e.fields, k) {
+			errs = append(errs, fmt.Errorf("unknown field %q", k))
+		}
+	}
+
+	reqPtr, reqErr := optBoolPtr(spec, "required")
+	if reqErr != nil {
+		errs = append(errs, reqErr)
+	}
+
+	if len(errs) > 0 {
+		return nil, joinLimited(errs, r.MaxReportedErrors)
+	}
+
+	rule, err := e.factory(spec, r)
+	if err != nil {
+		return nil, err
+	}
+
+	if reqPtr != nil && *reqPtr {
+		rule = Required(rule)
+	}
+	return rule, nil
+}
+
+// ParseQueryRules builds QueryRules from spec using BuiltinRegistry().
+// spec must be a map whose keys are tree queries and whose values are
+// rule specs (each a map containing at minimum a "type" field).
+func ParseQueryRules(spec tree.Node) (QueryRules, error) {
+	return ParseQueryRulesWith(spec, BuiltinRegistry())
+}
+
+// ParseQueryRulesWith is ParseQueryRules but dispatches through reg,
+// allowing custom rule types to be resolved. Errors from individual
+// queries are aggregated and capped at reg.MaxReportedErrors.
+func ParseQueryRulesWith(spec tree.Node, reg *Registry) (QueryRules, error) {
+	if !spec.Type().IsMap() {
+		return nil, fmt.Errorf("query rules spec must be map, got %s", spec.Type())
+	}
+	m := spec.Map()
+	out := QueryRules{}
+	var errs []error
+	for _, k := range m.Keys() {
+		r, err := reg.Parse(m[k])
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", k, err))
+			continue
+		}
+		out[k] = r
+	}
+	if len(errs) > 0 {
+		return nil, joinLimited(errs, reg.MaxReportedErrors)
+	}
+	return out, nil
+}
+
+// joinLimited joins up to max errors via errors.Join; overflow is
+// collapsed into a trailing "and N more errors" entry. max <= 0
+// disables the cap.
+func joinLimited(errs []error, max int) error {
+	if max <= 0 || len(errs) <= max {
+		return errors.Join(errs...)
+	}
+	head := make([]error, 0, max+1)
+	head = append(head, errs[:max]...)
+	head = append(head, fmt.Errorf("and %d more errors", len(errs)-max))
+	return errors.Join(head...)
+}
+
+// -- Built-in factories --
+
+func parseRequireSpec(_ tree.Node, _ *Registry) (Rule, error) {
+	return Require{}, nil
+}
+
+func parseStringSpec(spec tree.Node, _ *Registry) (Rule, error) {
+	r := String{}
+	var err error
+	if r.Enum, err = optStringSlice(spec, "enum"); err != nil {
+		return nil, err
+	}
+	pat, err := optStringVal(spec, "regex")
+	if err != nil {
+		return nil, err
+	}
+	if pat != "" {
+		re, err := regexp.Compile(pat)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex %q: %w", pat, err)
+		}
+		r.Regex = re
+	}
+	if r.MinLen, err = optIntPtr(spec, "minLen"); err != nil {
+		return nil, err
+	}
+	if r.MaxLen, err = optIntPtr(spec, "maxLen"); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func parseIntSpec(spec tree.Node, _ *Registry) (Rule, error) {
+	r := Int{}
+	var err error
+	if r.Min, err = optInt64Ptr(spec, "min"); err != nil {
+		return nil, err
+	}
+	if r.Max, err = optInt64Ptr(spec, "max"); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func parseFloatSpec(spec tree.Node, _ *Registry) (Rule, error) {
+	r := Float{}
+	var err error
+	if r.Min, err = optFloat64Ptr(spec, "min"); err != nil {
+		return nil, err
+	}
+	if r.Max, err = optFloat64Ptr(spec, "max"); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func parseBoolSpec(_ tree.Node, _ *Registry) (Rule, error) {
+	return Bool{}, nil
+}
+
+func parseArraySpec(spec tree.Node, _ *Registry) (Rule, error) {
+	r := Array{}
+	var err error
+	if r.MinLen, err = optIntPtr(spec, "minLen"); err != nil {
+		return nil, err
+	}
+	if r.MaxLen, err = optIntPtr(spec, "maxLen"); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func parseMapSpec(spec tree.Node, _ *Registry) (Rule, error) {
+	r := Map{}
+	ks, err := optStringSlice(spec, "keys")
+	if err != nil {
+		return nil, err
+	}
+	r.Keys = ks
+	return r, nil
+}
+
+func parseAndSpec(spec tree.Node, reg *Registry) (Rule, error) {
+	rs, err := parseOfArray("and", spec, reg)
+	if err != nil {
+		return nil, err
+	}
+	return And(rs), nil
+}
+
+func parseOrSpec(spec tree.Node, reg *Registry) (Rule, error) {
+	rs, err := parseOfArray("or", spec, reg)
+	if err != nil {
+		return nil, err
+	}
+	return Or(rs), nil
+}
+
+func parseNotSpec(spec tree.Node, reg *Registry) (Rule, error) {
+	inner := spec.Get("rule")
+	if inner.IsNil() {
+		return nil, fmt.Errorf("not: 'rule' is required")
+	}
+	r, err := reg.Parse(inner)
+	if err != nil {
+		return nil, fmt.Errorf("not.rule: %w", err)
+	}
+	return Not{Rule: r}, nil
+}
+
+func parseEverySpec(spec tree.Node, reg *Registry) (Rule, error) {
+	rulesSpec := spec.Get("rules")
+	if rulesSpec.IsNil() {
+		return nil, fmt.Errorf("every: 'rules' is required")
+	}
+	rules, err := ParseQueryRulesWith(rulesSpec, reg)
+	if err != nil {
+		return nil, fmt.Errorf("every.rules: %w", err)
+	}
+	return Every{Rules: rules}, nil
+}
+
+func parseOfArray(kind string, spec tree.Node, reg *Registry) ([]Rule, error) {
+	of := spec.Get("of")
+	if of.IsNil() {
+		return nil, fmt.Errorf("%s: 'of' is required", kind)
+	}
+	if !of.Type().IsArray() {
+		return nil, fmt.Errorf("%s: 'of' must be array, got %s", kind, of.Type())
+	}
+	arr := of.Array()
+	rs := make([]Rule, 0, len(arr))
+	for i, child := range arr {
+		r, err := reg.Parse(child)
+		if err != nil {
+			return nil, fmt.Errorf("%s.of[%d]: %w", kind, i, err)
+		}
+		rs = append(rs, r)
+	}
+	return rs, nil
+}
+
+// -- Field extractors --
+//
+// Each returns the zero value with nil error when the field is absent,
+// the converted value with nil error when it is present and well-typed,
+// or an error describing the type mismatch.
+
+func optStringVal(spec tree.Node, key string) (string, error) {
+	n := spec.Get(key)
+	if n.IsNil() {
+		return "", nil
+	}
+	if !n.Type().IsStringValue() {
+		return "", fmt.Errorf("%q must be string, got %s", key, n.Type())
+	}
+	return n.Value().String(), nil
+}
+
+func optStringSlice(spec tree.Node, key string) ([]string, error) {
+	n := spec.Get(key)
+	if n.IsNil() {
+		return nil, nil
+	}
+	if !n.Type().IsArray() {
+		return nil, fmt.Errorf("%q must be array, got %s", key, n.Type())
+	}
+	arr := n.Array()
+	out := make([]string, 0, len(arr))
+	for i, v := range arr {
+		if !v.Type().IsStringValue() {
+			return nil, fmt.Errorf("%q[%d] must be string, got %s", key, i, v.Type())
+		}
+		out = append(out, v.Value().String())
+	}
+	return out, nil
+}
+
+func optBoolPtr(spec tree.Node, key string) (*bool, error) {
+	n := spec.Get(key)
+	if n.IsNil() {
+		return nil, nil
+	}
+	if !n.Type().IsBoolValue() {
+		return nil, fmt.Errorf("%q must be bool, got %s", key, n.Type())
+	}
+	v := n.Value().Bool()
+	return &v, nil
+}
+
+func optIntPtr(spec tree.Node, key string) (*int, error) {
+	n := spec.Get(key)
+	if n.IsNil() {
+		return nil, nil
+	}
+	if !n.Type().IsNumberValue() {
+		return nil, fmt.Errorf("%q must be integer, got %s", key, n.Type())
+	}
+	f := n.Value().Float64()
+	if f != float64(int64(f)) {
+		return nil, fmt.Errorf("%q must be integer, got %v", key, f)
+	}
+	v := n.Value().Int()
+	return &v, nil
+}
+
+func optInt64Ptr(spec tree.Node, key string) (*int64, error) {
+	n := spec.Get(key)
+	if n.IsNil() {
+		return nil, nil
+	}
+	if !n.Type().IsNumberValue() {
+		return nil, fmt.Errorf("%q must be integer, got %s", key, n.Type())
+	}
+	f := n.Value().Float64()
+	if f != float64(int64(f)) {
+		return nil, fmt.Errorf("%q must be integer, got %v", key, f)
+	}
+	v := n.Value().Int64()
+	return &v, nil
+}
+
+func optFloat64Ptr(spec tree.Node, key string) (*float64, error) {
+	n := spec.Get(key)
+	if n.IsNil() {
+		return nil, nil
+	}
+	if !n.Type().IsNumberValue() {
+		return nil, fmt.Errorf("%q must be number, got %s", key, n.Type())
+	}
+	v := n.Value().Float64()
+	return &v, nil
+}

--- a/schema/registry_test.go
+++ b/schema/registry_test.go
@@ -1,0 +1,479 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mojatter/tree"
+)
+
+func TestBuiltinRegistry(t *testing.T) {
+	r := BuiltinRegistry()
+	wantTypes := []string{"require", "string", "int", "float", "bool", "array", "map", "and", "or", "not"}
+	for _, name := range wantTypes {
+		if _, ok := r.entries[name]; !ok {
+			t.Errorf("BuiltinRegistry missing %q", name)
+		}
+	}
+	if r.MaxReportedErrors != 20 {
+		t.Errorf("MaxReportedErrors = %d, want 20", r.MaxReportedErrors)
+	}
+}
+
+func TestRegistry_Register(t *testing.T) {
+	r := NewRegistry()
+	r.Register("x", func(_ tree.Node, _ *Registry) (Rule, error) { return Require{}, nil }, "a", "b")
+	e, ok := r.entries["x"]
+	if !ok {
+		t.Fatal("x not registered")
+	}
+	if len(e.fields) != 2 || e.fields[0] != "a" || e.fields[1] != "b" {
+		t.Errorf("fields = %v, want [a b]", e.fields)
+	}
+}
+
+func TestRegistry_Parse(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		spec     tree.Node
+		wantErrs []string // substrings; empty means success
+	}{
+		{
+			caseName: "spec not a map",
+			spec:     tree.V("x"),
+			wantErrs: []string{"rule spec must be map"},
+		},
+		{
+			caseName: "missing type",
+			spec:     tree.Map{"enum": tree.A("a")},
+			wantErrs: []string{"rule spec missing 'type'"},
+		},
+		{
+			caseName: "type not string",
+			spec:     tree.Map{"type": tree.V(42)},
+			wantErrs: []string{"'type' must be string"},
+		},
+		{
+			caseName: "type empty",
+			spec:     tree.Map{"type": tree.V("")},
+			wantErrs: []string{"'type' must not be empty"},
+		},
+		{
+			caseName: "unknown type",
+			spec:     tree.Map{"type": tree.V("uuid")},
+			wantErrs: []string{`unknown rule type "uuid"`},
+		},
+		{
+			caseName: "unknown field",
+			spec:     tree.Map{"type": tree.V("string"), "foo": tree.V(1)},
+			wantErrs: []string{`unknown field "foo"`},
+		},
+		{
+			caseName: "required not bool",
+			spec:     tree.Map{"type": tree.V("string"), "required": tree.V("yes")},
+			wantErrs: []string{`"required" must be bool, got string`},
+		},
+		{
+			caseName: "valid string",
+			spec:     tree.Map{"type": tree.V("string"), "enum": tree.A("a", "b")},
+		},
+		{
+			caseName: "string regex compiled at parse time",
+			spec:     tree.Map{"type": tree.V("string"), "regex": tree.V(`^\d+$`)},
+		},
+		{
+			caseName: "string invalid regex fails parse",
+			spec:     tree.Map{"type": tree.V("string"), "regex": tree.V(`[`)},
+			wantErrs: []string{`invalid regex "["`},
+		},
+		{
+			caseName: "string min len type mismatch",
+			spec:     tree.Map{"type": tree.V("string"), "minLen": tree.V("zero")},
+			wantErrs: []string{`"minLen" must be integer, got string`},
+		},
+		{
+			caseName: "int min not integer",
+			spec:     tree.Map{"type": tree.V("int"), "min": tree.V(1.5)},
+			wantErrs: []string{`"min" must be integer`},
+		},
+		{
+			caseName: "float min string",
+			spec:     tree.Map{"type": tree.V("float"), "min": tree.V("zero")},
+			wantErrs: []string{`"min" must be number, got string`},
+		},
+		{
+			caseName: "map keys not array",
+			spec:     tree.Map{"type": tree.V("map"), "keys": tree.V("name")},
+			wantErrs: []string{`"keys" must be array`},
+		},
+		{
+			caseName: "array minLen type mismatch",
+			spec:     tree.Map{"type": tree.V("array"), "minLen": tree.V("one")},
+			wantErrs: []string{`"minLen" must be integer, got string`},
+		},
+		{
+			caseName: "array maxLen type mismatch",
+			spec:     tree.Map{"type": tree.V("array"), "maxLen": tree.V(true)},
+			wantErrs: []string{`"maxLen" must be integer, got bool`},
+		},
+		{
+			caseName: "map keys element not string",
+			spec:     tree.Map{"type": tree.V("map"), "keys": tree.A("a", 1)},
+			wantErrs: []string{`"keys"[1] must be string`},
+		},
+		{
+			caseName: "and missing of",
+			spec:     tree.Map{"type": tree.V("and")},
+			wantErrs: []string{"and: 'of' is required"},
+		},
+		{
+			caseName: "or of not array",
+			spec:     tree.Map{"type": tree.V("or"), "of": tree.V("nope")},
+			wantErrs: []string{"or: 'of' must be array"},
+		},
+		{
+			caseName: "not missing rule",
+			spec:     tree.Map{"type": tree.V("not")},
+			wantErrs: []string{"not: 'rule' is required"},
+		},
+		{
+			caseName: "not rule nested error",
+			spec:     tree.Map{"type": tree.V("not"), "rule": tree.Map{"type": tree.V("unknown")}},
+			wantErrs: []string{`not.rule: unknown rule type "unknown"`},
+		},
+		{
+			caseName: "every missing rules",
+			spec:     tree.Map{"type": tree.V("every")},
+			wantErrs: []string{"every: 'rules' is required"},
+		},
+		{
+			caseName: "every nested error",
+			spec: tree.Map{
+				"type":  tree.V("every"),
+				"rules": tree.Map{".x": tree.Map{"type": tree.V("bogus")}},
+			},
+			wantErrs: []string{`every.rules: .x: unknown rule type "bogus"`},
+		},
+		{
+			caseName: "and of element error",
+			spec: tree.Map{
+				"type": tree.V("and"),
+				"of":   tree.A(tree.Map{"type": tree.V("string")}, tree.Map{"type": tree.V("bogus")}),
+			},
+			wantErrs: []string{`and.of[1]: unknown rule type "bogus"`},
+		},
+		{
+			caseName: "multiple unknown fields aggregated",
+			spec: tree.Map{
+				"type": tree.V("string"),
+				"bogus1": tree.V(1),
+				"bogus2": tree.V(2),
+			},
+			wantErrs: []string{`unknown field "bogus1"`, `unknown field "bogus2"`},
+		},
+	}
+	r := BuiltinRegistry()
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			_, err := r.Parse(tc.spec)
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestRegistry_Parse_RequiredWraps(t *testing.T) {
+	r := BuiltinRegistry()
+	spec := tree.Map{"type": tree.V("string"), "required": tree.V(true)}
+	rule, err := r.Parse(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Required(String{}) == And{Require{}, String{}}
+	if err := rule.Validate(tree.Nil, ".x"); err == nil {
+		t.Error("required wrap: want error on Nil")
+	}
+	if err := rule.Validate(tree.V("hi"), ".x"); err != nil {
+		t.Errorf("required wrap: unexpected %v", err)
+	}
+}
+
+func TestRegistry_Parse_RequiredFalseNotWrapped(t *testing.T) {
+	r := BuiltinRegistry()
+	spec := tree.Map{"type": tree.V("string"), "required": tree.V(false)}
+	rule, err := r.Parse(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Not wrapped: Nil must be OK.
+	if err := rule.Validate(tree.Nil, ".x"); err != nil {
+		t.Errorf("required:false should not wrap; got %v", err)
+	}
+}
+
+func TestRegistry_Parse_Require(t *testing.T) {
+	r := BuiltinRegistry()
+	rule, err := r.Parse(tree.Map{"type": tree.V("require")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := rule.(Require); !ok {
+		t.Errorf("got %T; want Require", rule)
+	}
+	if err := rule.Validate(tree.Nil, ".x"); err == nil {
+		t.Error("Require on Nil: want error")
+	}
+	if err := rule.Validate(tree.V("x"), ".x"); err != nil {
+		t.Errorf("Require on present: unexpected %v", err)
+	}
+}
+
+func TestRegistry_Parse_Array(t *testing.T) {
+	r := BuiltinRegistry()
+	rule, err := r.Parse(tree.Map{
+		"type":   tree.V("array"),
+		"minLen": tree.V(1),
+		"maxLen": tree.V(3),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	arr, ok := rule.(Array)
+	if !ok {
+		t.Fatalf("got %T; want Array", rule)
+	}
+	if arr.MinLen == nil || *arr.MinLen != 1 {
+		t.Errorf("MinLen = %v; want *1", arr.MinLen)
+	}
+	if arr.MaxLen == nil || *arr.MaxLen != 3 {
+		t.Errorf("MaxLen = %v; want *3", arr.MaxLen)
+	}
+	// Round-trip: validator should enforce the bounds.
+	if err := arr.Validate(tree.A(), ".x"); err == nil {
+		t.Error("empty array: want MinLen violation")
+	}
+	if err := arr.Validate(tree.A("a", "b", "c", "d"), ".x"); err == nil {
+		t.Error("4-element array: want MaxLen violation")
+	}
+	if err := arr.Validate(tree.A("a", "b"), ".x"); err != nil {
+		t.Errorf("2-element array: unexpected %v", err)
+	}
+}
+
+func TestParseQueryRules(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		spec     tree.Node
+		wantErrs []string
+	}{
+		{
+			caseName: "spec not a map",
+			spec:     tree.V("x"),
+			wantErrs: []string{"query rules spec must be map"},
+		},
+		{
+			caseName: "valid mixed rules",
+			spec: tree.Map{
+				".name":   tree.Map{"type": tree.V("string"), "required": tree.V(true)},
+				".age":    tree.Map{"type": tree.V("int"), "min": tree.V(0)},
+				".tags[]": tree.Map{"type": tree.V("string")},
+			},
+		},
+		{
+			caseName: "per-query errors prefixed with query path",
+			spec: tree.Map{
+				".name": tree.Map{"type": tree.V("string"), "bogus": tree.V(1)},
+				".age":  tree.Map{"type": tree.V("missing")},
+			},
+			wantErrs: []string{
+				`.age: unknown rule type "missing"`,
+				`.name: unknown field "bogus"`,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			rules, err := ParseQueryRules(tc.spec)
+			if len(tc.wantErrs) == 0 {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if rules == nil {
+					t.Error("rules == nil")
+				}
+				return
+			}
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestParseQueryRules_RoundTrip(t *testing.T) {
+	// spec → rules → run Validate → get expected errors.
+	spec := tree.Map{
+		".name":   tree.Map{"type": tree.V("string"), "required": tree.V(true)},
+		".age":    tree.Map{"type": tree.V("int"), "min": tree.V(0), "max": tree.V(150)},
+		".tags[]": tree.Map{"type": tree.V("string")},
+		".role": tree.Map{
+			"type": tree.V("or"),
+			"of": tree.A(
+				tree.Map{"type": tree.V("string"), "enum": tree.A("admin", "user")},
+				tree.Map{"type": tree.V("bool")},
+			),
+		},
+	}
+	rules, err := ParseQueryRules(spec)
+	if err != nil {
+		t.Fatalf("ParseQueryRules: %v", err)
+	}
+
+	doc := tree.Map{
+		"name": tree.V("alice"),
+		"age":  tree.V(-1), // < min
+		"tags": tree.A("a", 2, "b"), // element [1] not string
+		"role": tree.V("guest"),     // not in enum, not bool
+	}
+	err = Validate(doc, rules)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	wants := []string{
+		".age: value -1 less than min 0",
+		".tags[1]: expected string",
+		".role: value \"guest\" not in enum",
+	}
+	for _, w := range wants {
+		if !strings.Contains(err.Error(), w) {
+			t.Errorf("error %q missing %q", err.Error(), w)
+		}
+	}
+}
+
+func TestRegistry_Parse_Every(t *testing.T) {
+	r := BuiltinRegistry()
+	spec := tree.Map{
+		"type": tree.V("every"),
+		"rules": tree.Map{
+			".name": tree.Map{"type": tree.V("string"), "required": tree.V(true)},
+		},
+	}
+	rule, err := r.Parse(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	doc := tree.A(
+		tree.Map{"name": tree.V("alice")},
+		tree.Map{"count": tree.V(1)}, // missing name
+	)
+	err = rule.Validate(doc, ".tags")
+	if err == nil {
+		t.Fatal("want error on missing name")
+	}
+	want := ".tags[1].name: required"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q missing %q", err, want)
+	}
+}
+
+func TestParseQueryRulesWith_CustomType(t *testing.T) {
+	reg := BuiltinRegistry()
+	reg.Register("positive", func(_ tree.Node, _ *Registry) (Rule, error) {
+		return positiveRule{}, nil
+	})
+	spec := tree.Map{
+		".x": tree.Map{"type": tree.V("positive")},
+	}
+	rules, err := ParseQueryRulesWith(spec, reg)
+	if err != nil {
+		t.Fatalf("ParseQueryRulesWith: %v", err)
+	}
+
+	if err := Validate(tree.Map{"x": tree.V(5)}, rules); err != nil {
+		t.Errorf("positive on 5: unexpected %v", err)
+	}
+	if err := Validate(tree.Map{"x": tree.V(-1)}, rules); err == nil {
+		t.Error("positive on -1: want error")
+	}
+}
+
+type positiveRule struct{}
+
+func (positiveRule) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	if !n.Type().IsNumberValue() {
+		return strErr(q + ": expected number")
+	}
+	if n.Value().Float64() <= 0 {
+		return strErr(q + ": must be positive")
+	}
+	return nil
+}
+
+type strErr string
+
+func (e strErr) Error() string { return string(e) }
+
+func TestJoinLimited(t *testing.T) {
+	mk := func(n int) []error {
+		errs := make([]error, n)
+		for i := range errs {
+			errs[i] = strErr("e" + string(rune('0'+i)))
+		}
+		return errs
+	}
+	testCases := []struct {
+		caseName string
+		errs     []error
+		max      int
+		wantIn   []string
+		wantNot  []string
+	}{
+		{caseName: "none", errs: nil, max: 2},
+		{caseName: "under cap", errs: mk(2), max: 5, wantIn: []string{"e0", "e1"}, wantNot: []string{"more errors"}},
+		{caseName: "equal cap", errs: mk(5), max: 5, wantIn: []string{"e0", "e4"}, wantNot: []string{"more errors"}},
+		{caseName: "over cap", errs: mk(7), max: 3, wantIn: []string{"e0", "e1", "e2", "and 4 more errors"}, wantNot: []string{"e3", "e4"}},
+		{caseName: "zero cap means unlimited", errs: mk(10), max: 0, wantIn: []string{"e0", "e9"}, wantNot: []string{"more errors"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := joinLimited(tc.errs, tc.max)
+			if len(tc.errs) == 0 {
+				if err != nil {
+					t.Fatalf("empty: want nil, got %v", err)
+				}
+				return
+			}
+			s := err.Error()
+			for _, w := range tc.wantIn {
+				if !strings.Contains(s, w) {
+					t.Errorf("missing %q in %q", w, s)
+				}
+			}
+			for _, w := range tc.wantNot {
+				if strings.Contains(s, w) {
+					t.Errorf("unexpected %q in %q", w, s)
+				}
+			}
+		})
+	}
+}
+
+func TestParseQueryRulesWith_ErrorCap(t *testing.T) {
+	reg := BuiltinRegistry()
+	reg.MaxReportedErrors = 3
+	spec := tree.Map{}
+	// Build 5 broken rules; errors sort by key so ".e0" .. ".e4".
+	for i := range 5 {
+		key := "." + string(rune('a'+i))
+		spec[key] = tree.Map{"type": tree.V("nope")}
+	}
+	_, err := ParseQueryRulesWith(spec, reg)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	s := err.Error()
+	if !strings.Contains(s, "and 2 more errors") {
+		t.Errorf("missing cap summary; got %q", s)
+	}
+}

--- a/schema/rules.go
+++ b/schema/rules.go
@@ -1,0 +1,321 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"slices"
+
+	"github.com/mojatter/tree"
+)
+
+// Required wraps r so the node must exist. It is shorthand for
+// And{Require{}, r} and works uniformly for both leaf rules and
+// composites. If r is already a Required wrapper, Required(r) is
+// returned unchanged so double wrapping does not produce duplicate
+// "required" errors.
+func Required(r Rule) Rule {
+	if a, ok := r.(And); ok && len(a) > 0 {
+		if _, ok := a[0].(Require); ok {
+			return r
+		}
+	}
+	return And{Require{}, r}
+}
+
+// IntPtr, Int64Ptr, and Float64Ptr return a pointer to v. They are
+// convenience helpers for constructing pointer-valued rule fields
+// (String.MinLen, Int.Min, Float.Max, etc.) inline.
+
+// IntPtr returns a pointer to v.
+func IntPtr(v int) *int { return &v }
+
+// Int64Ptr returns a pointer to v.
+func Int64Ptr(v int64) *int64 { return &v }
+
+// Float64Ptr returns a pointer to v.
+func Float64Ptr(v float64) *float64 { return &v }
+
+// Require fires an error when the node is tree.Nil (query matched
+// nothing). It is the only rule that treats Nil as a violation.
+type Require struct{}
+
+// Validate implements Rule.
+func (Require) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return fmt.Errorf("%s: required", q)
+	}
+	return nil
+}
+
+// And passes only if every child rule passes. All child errors are
+// collected (not short-circuited) so the caller sees every violation
+// at once.
+type And []Rule
+
+// Validate implements Rule.
+func (rs And) Validate(n tree.Node, q string) error {
+	var errs []error
+	for _, r := range rs {
+		if err := r.Validate(n, q); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Or passes if at least one child rule passes. On Nil it returns nil
+// (skip) to stay consistent with leaf rules; use Required(Or{...}) to
+// force presence.
+type Or []Rule
+
+// Validate implements Rule.
+func (rs Or) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	var errs []error
+	for _, r := range rs {
+		err := r.Validate(n, q)
+		if err == nil {
+			return nil
+		}
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// Every applies a set of QueryRules to each element of an array or
+// each value of a map. Error paths include the concrete index
+// (.foo[0]) or key (.foo["a"]) of the element. On Nil it returns nil
+// (skip); wrap with Required to require presence.
+//
+// Unlike the bare "[]" suffix at the top level, which flattens
+// matches and therefore cannot detect a specific element that is
+// missing a required sub-field, Every runs its rules starting from
+// each element individually, so Required(r) in Rules fires per
+// element.
+type Every struct {
+	Rules QueryRules
+}
+
+// Validate implements Rule.
+func (r Every) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	var errs []error
+	switch {
+	case n.Type().IsArray():
+		for i, v := range n.Array() {
+			prefix := fmt.Sprintf("%s[%d]", q, i)
+			sub, fe := validateNode(v, r.Rules, prefix)
+			if fe != nil {
+				return fe
+			}
+			errs = append(errs, sub...)
+		}
+	case n.Type().IsMap():
+		m := n.Map()
+		for _, k := range m.Keys() {
+			prefix := fmt.Sprintf("%s[%q]", q, k)
+			sub, fe := validateNode(m[k], r.Rules, prefix)
+			if fe != nil {
+				return fe
+			}
+			errs = append(errs, sub...)
+		}
+	default:
+		return fmt.Errorf("%s: expected array or map, got %s", q, n.Type())
+	}
+	return errors.Join(errs...)
+}
+
+// Not passes if the inner rule fails. On Nil it returns nil so a
+// missing node is not treated as "matched"; wrap with Required to
+// require presence.
+type Not struct {
+	Rule Rule
+}
+
+// Validate implements Rule.
+func (r Not) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	if err := r.Rule.Validate(n, q); err != nil {
+		return nil
+	}
+	return fmt.Errorf("%s: unexpected match", q)
+}
+
+// String matches a string-typed value. All constraint fields are
+// optional; unset ones do not constrain. Regex is a pre-compiled
+// pattern so Validate has no per-call compile cost; use
+// regexp.MustCompile (or regexp.Compile) at construction time.
+type String struct {
+	Enum   []string
+	Regex  *regexp.Regexp
+	MinLen *int
+	MaxLen *int
+}
+
+// Validate implements Rule.
+func (r String) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	if !n.Type().IsStringValue() {
+		return fmt.Errorf("%s: expected string, got %s", q, n.Type())
+	}
+	s := n.Value().String()
+	if len(r.Enum) > 0 && !slices.Contains(r.Enum, s) {
+		return fmt.Errorf("%s: value %q not in enum %v", q, s, r.Enum)
+	}
+	if r.Regex != nil && !r.Regex.MatchString(s) {
+		return fmt.Errorf("%s: value %q does not match %q", q, s, r.Regex)
+	}
+	if r.MinLen != nil && len(s) < *r.MinLen {
+		return fmt.Errorf("%s: length %d less than min %d", q, len(s), *r.MinLen)
+	}
+	if r.MaxLen != nil && len(s) > *r.MaxLen {
+		return fmt.Errorf("%s: length %d greater than max %d", q, len(s), *r.MaxLen)
+	}
+	return nil
+}
+
+// Int matches an integer-valued number (fractional values are
+// rejected). tree stores numbers as float64, so "is integer" is
+// checked by comparing the value with its truncation.
+type Int struct {
+	Min *int64
+	Max *int64
+}
+
+// Validate implements Rule.
+func (r Int) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	if !n.Type().IsNumberValue() {
+		return fmt.Errorf("%s: expected number, got %s", q, n.Type())
+	}
+	f := n.Value().Float64()
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return fmt.Errorf("%s: expected integer, got %v", q, f)
+	}
+	// int64 range check before conversion; values outside (MinInt64,
+	// MaxInt64] cannot be represented exactly as int64.
+	if f < math.MinInt64 || f > math.MaxInt64 {
+		return fmt.Errorf("%s: expected integer, got %v", q, f)
+	}
+	if f != math.Trunc(f) {
+		return fmt.Errorf("%s: expected integer, got %v", q, f)
+	}
+	i := int64(f)
+	if r.Min != nil && i < *r.Min {
+		return fmt.Errorf("%s: value %d less than min %d", q, i, *r.Min)
+	}
+	if r.Max != nil && i > *r.Max {
+		return fmt.Errorf("%s: value %d greater than max %d", q, i, *r.Max)
+	}
+	return nil
+}
+
+// Float matches any number with optional float bounds.
+type Float struct {
+	Min *float64
+	Max *float64
+}
+
+// Validate implements Rule.
+func (r Float) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	if !n.Type().IsNumberValue() {
+		return fmt.Errorf("%s: expected number, got %s", q, n.Type())
+	}
+	f := n.Value().Float64()
+	// NaN fails any ordered comparison, which would silently slip past
+	// Min/Max checks; reject it explicitly so the rule never accepts a
+	// value it cannot order.
+	if math.IsNaN(f) {
+		return fmt.Errorf("%s: NaN is not allowed", q)
+	}
+	if r.Min != nil && f < *r.Min {
+		return fmt.Errorf("%s: value %v less than min %v", q, f, *r.Min)
+	}
+	if r.Max != nil && f > *r.Max {
+		return fmt.Errorf("%s: value %v greater than max %v", q, f, *r.Max)
+	}
+	return nil
+}
+
+// Bool matches a boolean value.
+type Bool struct{}
+
+// Validate implements Rule.
+func (Bool) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	if !n.Type().IsBoolValue() {
+		return fmt.Errorf("%s: expected bool, got %s", q, n.Type())
+	}
+	return nil
+}
+
+// Array matches an array with optional length bounds. Element rules
+// are expressed as separate entries in QueryRules (e.g. ".arr[]").
+type Array struct {
+	MinLen *int
+	MaxLen *int
+}
+
+// Validate implements Rule.
+func (r Array) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	if !n.Type().IsArray() {
+		return fmt.Errorf("%s: expected array, got %s", q, n.Type())
+	}
+	length := len(n.Array())
+	if r.MinLen != nil && length < *r.MinLen {
+		return fmt.Errorf("%s: length %d less than min %d", q, length, *r.MinLen)
+	}
+	if r.MaxLen != nil && length > *r.MaxLen {
+		return fmt.Errorf("%s: length %d greater than max %d", q, length, *r.MaxLen)
+	}
+	return nil
+}
+
+// Map matches a map. When Keys is non-empty, any key outside the
+// allow-list is reported (one error per unknown key, keys sorted for
+// stable output).
+type Map struct {
+	Keys []string
+}
+
+// Validate implements Rule.
+func (r Map) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	if !n.Type().IsMap() {
+		return fmt.Errorf("%s: expected map, got %s", q, n.Type())
+	}
+	if len(r.Keys) == 0 {
+		return nil
+	}
+	m := n.Map()
+	var errs []error
+	for _, k := range m.Keys() {
+		if !slices.Contains(r.Keys, k) {
+			errs = append(errs, fmt.Errorf("%s: unknown key %q", q, k))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/schema/rules_test.go
+++ b/schema/rules_test.go
@@ -1,0 +1,335 @@
+package schema
+
+import (
+	"math"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mojatter/tree"
+)
+
+func intPtr(v int) *int         { return &v }
+func int64Ptr(v int64) *int64   { return &v }
+func f64Ptr(v float64) *float64 { return &v }
+
+func TestRequire(t *testing.T) {
+	if err := (Require{}).Validate(tree.Nil, ".x"); err == nil {
+		t.Error("Require on Nil: want error")
+	}
+	if err := (Require{}).Validate(tree.V("x"), ".x"); err != nil {
+		t.Errorf("Require on present: unexpected %v", err)
+	}
+}
+
+func TestRequired_Idempotent(t *testing.T) {
+	// Required(Required(String{})) must still yield exactly one
+	// "required" error on Nil, not two.
+	r := Required(Required(String{}))
+	err := r.Validate(tree.Nil, ".x")
+	if err == nil {
+		t.Fatal("want error")
+	}
+	if got := strings.Count(err.Error(), "required"); got != 1 {
+		t.Errorf("required count = %d, want 1 (err=%q)", got, err.Error())
+	}
+}
+
+func TestAnd(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		rule     And
+		n        tree.Node
+		wantErrs []string
+	}{
+		{
+			caseName: "all pass",
+			rule:     And{Require{}, String{}},
+			n:        tree.V("x"),
+		},
+		{
+			caseName: "require fires, string skips on nil",
+			rule:     And{Require{}, String{}},
+			n:        tree.Nil,
+			wantErrs: []string{".x: required"},
+		},
+		{
+			caseName: "enum + length both fail",
+			rule:     And{String{Enum: []string{"a"}}, String{MaxLen: intPtr(0)}},
+			n:        tree.V("bb"),
+			wantErrs: []string{"not in enum", "length 2 greater than max 0"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.rule.Validate(tc.n, ".x")
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestOr(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		rule     Or
+		n        tree.Node
+		wantErrs []string
+	}{
+		{
+			caseName: "nil skipped",
+			rule:     Or{String{}, Int{}},
+			n:        tree.Nil,
+		},
+		{
+			caseName: "string branch passes",
+			rule:     Or{String{}, Int{}},
+			n:        tree.V("hi"),
+		},
+		{
+			caseName: "int branch passes",
+			rule:     Or{String{}, Int{}},
+			n:        tree.V(42),
+		},
+		{
+			caseName: "all branches fail",
+			rule:     Or{String{}, Int{}},
+			n:        tree.V(true),
+			wantErrs: []string{"expected string", "expected number"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.rule.Validate(tc.n, ".x")
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestNot(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		rule     Not
+		n        tree.Node
+		wantErrs []string
+	}{
+		{caseName: "nil skipped", rule: Not{Rule: String{}}, n: tree.Nil},
+		{caseName: "inner fails so Not passes", rule: Not{Rule: String{}}, n: tree.V(42)},
+		{caseName: "inner passes so Not fails", rule: Not{Rule: String{}}, n: tree.V("hi"), wantErrs: []string{".x: unexpected match"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.rule.Validate(tc.n, ".x")
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestEvery(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		rule     Every
+		n        tree.Node
+		wantErrs []string
+	}{
+		{
+			caseName: "nil skipped",
+			rule:     Every{Rules: QueryRules{".name": Required(String{})}},
+			n:        tree.Nil,
+		},
+		{
+			caseName: "non-collection rejected",
+			rule:     Every{Rules: QueryRules{".name": String{}}},
+			n:        tree.V("x"),
+			wantErrs: []string{".x: expected array or map, got string"},
+		},
+		{
+			caseName: "array all pass",
+			rule:     Every{Rules: QueryRules{".name": Required(String{})}},
+			n: tree.A(
+				tree.Map{"name": tree.V("alice")},
+				tree.Map{"name": tree.V("bob")},
+			),
+		},
+		{
+			caseName: "array with missing field fires Required per element",
+			rule:     Every{Rules: QueryRules{".name": Required(String{})}},
+			n: tree.A(
+				tree.Map{"name": tree.V("alice")},
+				tree.Map{"count": tree.V(1)}, // no "name"
+			),
+			wantErrs: []string{".x[1].name: required"},
+		},
+		{
+			caseName: "map values validated with concrete key path",
+			rule:     Every{Rules: QueryRules{".name": Required(String{})}},
+			n: tree.Map{
+				"a": tree.Map{"name": tree.V("ok")},
+				"b": tree.Map{"other": tree.V(1)},
+			},
+			wantErrs: []string{`.x["b"].name: required`},
+		},
+		{
+			caseName: "nested Every",
+			rule: Every{Rules: QueryRules{
+				".items": Every{Rules: QueryRules{
+					".id": Required(Int{}),
+				}},
+			}},
+			n: tree.A(
+				tree.Map{"items": tree.A(
+					tree.Map{"id": tree.V(1)},
+					tree.Map{"name": tree.V("x")}, // no "id"
+				)},
+			),
+			wantErrs: []string{".x[0].items[1].id: required"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.rule.Validate(tc.n, ".x")
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		rule     String
+		n        tree.Node
+		wantErrs []string
+	}{
+		{caseName: "nil skip", rule: String{}, n: tree.Nil},
+		{caseName: "plain string", rule: String{}, n: tree.V("x")},
+		{caseName: "not string", rule: String{}, n: tree.V(1), wantErrs: []string{".x: expected string, got number"}},
+		{caseName: "enum hit", rule: String{Enum: []string{"a", "b"}}, n: tree.V("a")},
+		{caseName: "enum miss", rule: String{Enum: []string{"a", "b"}}, n: tree.V("c"), wantErrs: []string{`.x: value "c" not in enum`}},
+		{caseName: "regex match", rule: String{Regex: regexp.MustCompile(`^\d+$`)}, n: tree.V("42")},
+		{caseName: "regex miss", rule: String{Regex: regexp.MustCompile(`^\d+$`)}, n: tree.V("abc"), wantErrs: []string{`.x: value "abc" does not match`}},
+		{caseName: "min len", rule: String{MinLen: intPtr(3)}, n: tree.V("ab"), wantErrs: []string{".x: length 2 less than min 3"}},
+		{caseName: "max len", rule: String{MaxLen: intPtr(2)}, n: tree.V("abc"), wantErrs: []string{".x: length 3 greater than max 2"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.rule.Validate(tc.n, ".x")
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestInt(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		rule     Int
+		n        tree.Node
+		wantErrs []string
+	}{
+		{caseName: "nil skip", rule: Int{}, n: tree.Nil},
+		{caseName: "plain int", rule: Int{}, n: tree.V(42)},
+		{caseName: "string rejected", rule: Int{}, n: tree.V("x"), wantErrs: []string{".x: expected number, got string"}},
+		{caseName: "float rejected", rule: Int{}, n: tree.V(1.5), wantErrs: []string{".x: expected integer, got 1.5"}},
+		{caseName: "whole float ok", rule: Int{}, n: tree.V(3.0)},
+		{caseName: "NaN rejected", rule: Int{}, n: tree.V(math.NaN()), wantErrs: []string{"expected integer"}},
+		{caseName: "+Inf rejected", rule: Int{}, n: tree.V(math.Inf(1)), wantErrs: []string{"expected integer"}},
+		{caseName: "-Inf rejected", rule: Int{}, n: tree.V(math.Inf(-1)), wantErrs: []string{"expected integer"}},
+		{caseName: "above int64 max rejected", rule: Int{}, n: tree.V(1e19), wantErrs: []string{"expected integer"}},
+		{caseName: "min ok", rule: Int{Min: int64Ptr(0)}, n: tree.V(1)},
+		{caseName: "min violated", rule: Int{Min: int64Ptr(0)}, n: tree.V(-1), wantErrs: []string{".x: value -1 less than min 0"}},
+		{caseName: "max violated", rule: Int{Max: int64Ptr(10)}, n: tree.V(11), wantErrs: []string{".x: value 11 greater than max 10"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.rule.Validate(tc.n, ".x")
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestFloat(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		rule     Float
+		n        tree.Node
+		wantErrs []string
+	}{
+		{caseName: "nil skip", rule: Float{}, n: tree.Nil},
+		{caseName: "float ok", rule: Float{}, n: tree.V(1.5)},
+		{caseName: "int ok", rule: Float{}, n: tree.V(1)},
+		{caseName: "string rejected", rule: Float{}, n: tree.V("x"), wantErrs: []string{".x: expected number, got string"}},
+		{caseName: "NaN rejected", rule: Float{Min: f64Ptr(0.0)}, n: tree.V(math.NaN()), wantErrs: []string{"NaN is not allowed"}},
+		{caseName: "min violated", rule: Float{Min: f64Ptr(0.0)}, n: tree.V(-0.5), wantErrs: []string{"less than min"}},
+		{caseName: "max violated", rule: Float{Max: f64Ptr(1.0)}, n: tree.V(1.5), wantErrs: []string{"greater than max"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.rule.Validate(tc.n, ".x")
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestBool(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		n        tree.Node
+		wantErrs []string
+	}{
+		{caseName: "nil skip", n: tree.Nil},
+		{caseName: "true", n: tree.V(true)},
+		{caseName: "false", n: tree.V(false)},
+		{caseName: "string rejected", n: tree.V("true"), wantErrs: []string{".x: expected bool, got string"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := (Bool{}).Validate(tc.n, ".x")
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestArray(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		rule     Array
+		n        tree.Node
+		wantErrs []string
+	}{
+		{caseName: "nil skip", rule: Array{}, n: tree.Nil},
+		{caseName: "plain array", rule: Array{}, n: tree.A("x")},
+		{caseName: "not array", rule: Array{}, n: tree.V("x"), wantErrs: []string{".x: expected array, got string"}},
+		{caseName: "min len violated", rule: Array{MinLen: intPtr(2)}, n: tree.A("x"), wantErrs: []string{".x: length 1 less than min 2"}},
+		{caseName: "max len violated", rule: Array{MaxLen: intPtr(1)}, n: tree.A("x", "y"), wantErrs: []string{".x: length 2 greater than max 1"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.rule.Validate(tc.n, ".x")
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestMap(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		rule     Map
+		n        tree.Node
+		wantErrs []string
+	}{
+		{caseName: "nil skip", rule: Map{}, n: tree.Nil},
+		{caseName: "plain map", rule: Map{}, n: tree.Map{}},
+		{caseName: "not map", rule: Map{}, n: tree.V("x"), wantErrs: []string{".x: expected map, got string"}},
+		{caseName: "no known keys allows any", rule: Map{}, n: tree.Map{"anything": tree.V(1)}},
+		{
+			caseName: "unknown keys reported sorted",
+			rule:     Map{Keys: []string{"a"}},
+			n:        tree.Map{"a": tree.V(1), "c": tree.V(2), "b": tree.V(3)},
+			wantErrs: []string{`.x: unknown key "b"`, `.x: unknown key "c"`},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := tc.rule.Validate(tc.n, ".x")
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,0 +1,169 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/mojatter/tree"
+)
+
+// Rule validates a single tree.Node reached via query q.
+//
+// q is a display path used for error messages; when Validate (top-level
+// function) drives the call, q is the query string, with array-element
+// rules (queries ending in []) having their suffix expanded to the
+// concrete index (e.g. .arr[0], .arr[1]).
+type Rule interface {
+	Validate(n tree.Node, q string) error
+}
+
+// QueryRules maps a tree query to the rule applied at each match.
+type QueryRules map[string]Rule
+
+// ErrQuery indicates that a rule's query string is malformed (tree.Find
+// rejected it). It represents a bug in the rules definition, not a
+// data violation, so Validate and ValidateWithPrefix fail fast and
+// return only this error instead of joining it with data-level
+// violation errors. Callers that want to distinguish can errors.As
+// into *ErrQuery.
+type ErrQuery struct {
+	Query string // joined display path (prefix + rule query) that failed to parse
+	Err   error  // underlying tree.Find error
+}
+
+// Error implements error.
+func (e *ErrQuery) Error() string {
+	return fmt.Sprintf("query %q: %s", e.Query, e.Err)
+}
+
+// Unwrap returns the underlying tree.Find error.
+func (e *ErrQuery) Unwrap() error {
+	return e.Err
+}
+
+// Validate executes every (query, rule) entry in rules against n.
+// Errors from all rules are collected and joined.
+//
+// For each query q, tree.Find is called. If q yields no matches, the
+// rule is invoked once with tree.Nil (so Require{} can fire). When q
+// ends with "[]", matches are reported with a concrete path:
+// .arr[0]/.arr[1]... for array parents and .obj["a"]/.obj["b"]...
+// for map parents (keys sorted). If the base of "[]" resolves to more
+// than one parent, numeric indices are used as the fallback.
+func Validate(n tree.Node, rules QueryRules) error {
+	return ValidateWithPrefix(n, rules, "")
+}
+
+// ValidateWithPrefix is Validate with a path prefix prepended to every
+// error location. It is intended for custom Rule implementations that
+// re-apply a QueryRules set to a subtree (think Every, but driven by
+// the enclosing node's content): the Rule can delegate to
+// ValidateWithPrefix(child, subRules, q) so nested error paths come
+// out as q + subquery (e.g. .handlers["c"].type) instead of bare
+// subqueries that the caller would otherwise have to splice in by
+// unwrapping and re-wrapping errors.
+//
+// prefix is concatenated as-is; pass "" to get the same behavior as
+// Validate.
+func ValidateWithPrefix(n tree.Node, rules QueryRules, prefix string) error {
+	errs, fe := validateNode(n, rules, prefix)
+	if fe != nil {
+		return fe
+	}
+	return errors.Join(errs...)
+}
+
+// validateNode is the shared driver behind Validate and Every. prefix
+// is prepended to every display path and query key so nested element
+// validation (via Every) can attribute errors to .parent[i].child.
+//
+// When a rule query fails to parse, it returns immediately with a
+// non-nil *ErrQuery and nil validation errors: a malformed query is a
+// bug in the rules, so reporting it alongside data-level violations
+// would just produce noise.
+func validateNode(n tree.Node, rules QueryRules, prefix string) ([]error, *ErrQuery) {
+	qs := slices.Sorted(maps.Keys(rules))
+
+	var errs []error
+	for _, q := range qs {
+		r := rules[q]
+		vs, err := tree.Find(n, q)
+		if err != nil {
+			return nil, &ErrQuery{Query: joinPath(prefix, q), Err: err}
+		}
+		if len(vs) == 0 {
+			if err := r.Validate(tree.Nil, joinPath(prefix, q)); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+		if base, ok := strings.CutSuffix(q, "[]"); ok {
+			sub, fe := validateExpanded(n, base, vs, r, prefix)
+			if fe != nil {
+				return nil, fe
+			}
+			errs = append(errs, sub...)
+			continue
+		}
+		display := joinPath(prefix, q)
+		for _, v := range vs {
+			if err := r.Validate(v, display); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs, nil
+}
+
+// validateExpanded runs r against each matched value of a "[]"-suffixed
+// query. When the base query resolves to a single map parent, error
+// paths include the concrete key (e.g. .obj["a"]); otherwise numeric
+// indices are used (e.g. .arr[0]). prefix is prepended to the base
+// so nested contexts (from Every) render full paths.
+//
+// A parse failure on the base query is propagated as *ErrQuery; in
+// practice this should not fire when the caller already parsed the
+// full "[]"-suffixed query successfully, but it is handled for safety.
+func validateExpanded(root tree.Node, base string, vs []tree.Node, r Rule, prefix string) ([]error, *ErrQuery) {
+	display := joinPath(prefix, base)
+	parents, err := tree.Find(root, base)
+	if err != nil {
+		return nil, &ErrQuery{Query: joinPath(prefix, base), Err: err}
+	}
+	if len(parents) == 1 && parents[0].Type().IsMap() {
+		m := parents[0].Map()
+		var errs []error
+		for _, k := range m.Keys() {
+			qi := fmt.Sprintf("%s[%q]", display, k)
+			if err := r.Validate(m[k], qi); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return errs, nil
+	}
+	var errs []error
+	for i, v := range vs {
+		qi := fmt.Sprintf("%s[%d]", display, i)
+		if err := r.Validate(v, qi); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs, nil
+}
+
+// joinPath concatenates a prefix path and a rule query into the
+// display path used in error messages. A rule query of "." refers to
+// the current node, so it drops to the bare prefix (or "." when the
+// prefix is empty for a top-level Validate call).
+func joinPath(prefix, q string) string {
+	if q == "." {
+		if prefix == "" {
+			return "."
+		}
+		return prefix
+	}
+	return prefix + q
+}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,0 +1,267 @@
+package schema
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mojatter/tree"
+)
+
+func TestValidate(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		n        tree.Node
+		rules    QueryRules
+		wantErrs []string // all substrings must appear; empty means no error
+	}{
+		{
+			caseName: "require fires on nil root",
+			n:        tree.Nil,
+			rules:    QueryRules{".": Require{}},
+			wantErrs: []string{".: required"},
+		},
+		{
+			caseName: "map known keys",
+			n: tree.Map{
+				"KNOWN":   tree.Nil,
+				"UNKNOWN": tree.Nil,
+			},
+			rules:    QueryRules{".": Map{Keys: []string{"KNOWN"}}},
+			wantErrs: []string{`.: unknown key "UNKNOWN"`},
+		},
+		{
+			caseName: "leaf skips on nil",
+			n:        tree.Map{},
+			rules:    QueryRules{".missing": String{}},
+		},
+		{
+			caseName: "required string present",
+			n:        tree.Map{"name": tree.V("alice")},
+			rules:    QueryRules{".name": Required(String{})},
+		},
+		{
+			caseName: "required string absent",
+			n:        tree.Map{},
+			rules:    QueryRules{".name": Required(String{})},
+			wantErrs: []string{".name: required"},
+		},
+		{
+			caseName: "array element errors carry concrete index",
+			n:        tree.Map{"arr": tree.A("ok", 1, true)},
+			rules:    QueryRules{".arr[]": String{}},
+			wantErrs: []string{".arr[1]: expected string", ".arr[2]: expected string"},
+		},
+		{
+			caseName: "map value errors carry concrete key",
+			n: tree.Map{"labels": tree.Map{
+				"admin": tree.V("x"),
+				"guest": tree.V(1),
+				"user":  tree.V(true),
+			}},
+			rules:    QueryRules{".labels[]": String{}},
+			wantErrs: []string{`.labels["guest"]: expected string`, `.labels["user"]: expected string`},
+		},
+		{
+			caseName: "map value error path is keyed not indexed",
+			n:        tree.Map{"labels": tree.Map{"k": tree.V(1)}},
+			rules:    QueryRules{".labels[]": String{}},
+			wantErrs: []string{`.labels["k"]`},
+		},
+		{
+			caseName: "errors collected across rules",
+			n: tree.Map{
+				"a": tree.V(1),
+				"b": tree.V(true),
+			},
+			rules: QueryRules{
+				".a": String{},
+				".b": Int{},
+			},
+			wantErrs: []string{".a: expected string, got number", ".b: expected number, got bool"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := Validate(tc.n, tc.rules)
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+func TestValidateWithPrefix(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		n        tree.Node
+		rules    QueryRules
+		prefix   string
+		wantErrs []string
+	}{
+		{
+			caseName: "empty prefix matches Validate",
+			n:        tree.Map{"name": tree.V(1)},
+			rules:    QueryRules{".name": String{}},
+			prefix:   "",
+			wantErrs: []string{".name: expected string"},
+		},
+		{
+			caseName: "prefix prepended to leaf error",
+			n:        tree.Map{"name": tree.V(1)},
+			rules:    QueryRules{".name": String{}},
+			prefix:   `.handlers["c"]`,
+			wantErrs: []string{`.handlers["c"].name: expected string`},
+		},
+		{
+			caseName: "prefix prepended to required",
+			n:        tree.Map{},
+			rules:    QueryRules{".name": Required(String{})},
+			prefix:   `.handlers["c"]`,
+			wantErrs: []string{`.handlers["c"].name: required`},
+		},
+		{
+			caseName: "prefix prepended to expanded array index",
+			n:        tree.Map{"arr": tree.A("ok", 1)},
+			rules:    QueryRules{".arr[]": String{}},
+			prefix:   `.handlers["c"]`,
+			wantErrs: []string{`.handlers["c"].arr[1]: expected string`},
+		},
+		{
+			caseName: `self query "." under prefix drops to bare prefix`,
+			n:        tree.V(1),
+			rules:    QueryRules{".": String{}},
+			prefix:   `.handlers["c"]`,
+			wantErrs: []string{`.handlers["c"]: expected string`},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := ValidateWithPrefix(tc.n, tc.rules, tc.prefix)
+			checkErrs(t, err, tc.wantErrs)
+		})
+	}
+}
+
+// dispatchRule mirrors the fasthttpd HandlerDispatch pattern: pick a
+// QueryRules set based on the node's content, then recurse with
+// ValidateWithPrefix so nested error paths are attributed to the
+// enclosing query.
+type dispatchRule struct {
+	byType map[string]QueryRules
+}
+
+func (r dispatchRule) Validate(n tree.Node, q string) error {
+	if n.IsNil() {
+		return nil
+	}
+	typ := n.Get("type").Value().String()
+	rules, ok := r.byType[typ]
+	if !ok {
+		return nil
+	}
+	return ValidateWithPrefix(n, rules, q)
+}
+
+func TestValidateWithPrefix_DispatchRule(t *testing.T) {
+	rule := dispatchRule{byType: map[string]QueryRules{
+		"http": {".port": Required(Int{})},
+	}}
+	n := tree.Map{"handlers": tree.Map{
+		"c": tree.Map{"type": tree.V("http")},
+	}}
+	err := Validate(n, QueryRules{`.handlers[]`: rule})
+	checkErrs(t, err, []string{`.handlers["c"].port: required`})
+}
+
+func TestValidate_ErrQuery(t *testing.T) {
+	testCases := []struct {
+		caseName  string
+		n         tree.Node
+		rules     QueryRules
+		wantQuery string
+	}{
+		{
+			caseName:  "malformed top-level query fails fast",
+			n:         tree.Map{"ok": tree.V("x")},
+			rules:     QueryRules{".ok": String{}, ".bad[": String{}},
+			wantQuery: ".bad[",
+		},
+		{
+			caseName:  "ErrQuery suppresses sibling validation errors",
+			n:         tree.Map{"ok": tree.V(1)}, // would fail String{} normally
+			rules:     QueryRules{".ok": String{}, ".bad[": String{}},
+			wantQuery: ".bad[",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			err := Validate(tc.n, tc.rules)
+			if err == nil {
+				t.Fatalf("got nil; want *ErrQuery")
+			}
+			var eq *ErrQuery
+			if !errors.As(err, &eq) {
+				t.Fatalf("got %T (%v); want *ErrQuery", err, err)
+			}
+			if eq.Query != tc.wantQuery {
+				t.Errorf("Query = %q; want %q", eq.Query, tc.wantQuery)
+			}
+			if eq.Err == nil {
+				t.Error("Unwrap returned nil; want underlying tree.Find error")
+			}
+			// Sibling String{} violation on .ok must NOT appear when ErrQuery fires.
+			if strings.Contains(err.Error(), "expected string") {
+				t.Errorf("ErrQuery should suppress sibling errors; got %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateWithPrefix_ErrQueryCarriesPrefix(t *testing.T) {
+	err := ValidateWithPrefix(tree.Map{}, QueryRules{".bad[": String{}}, `.handlers["c"]`)
+	var eq *ErrQuery
+	if !errors.As(err, &eq) {
+		t.Fatalf("got %T (%v); want *ErrQuery", err, err)
+	}
+	if want := `.handlers["c"].bad[`; eq.Query != want {
+		t.Errorf("Query = %q; want %q", eq.Query, want)
+	}
+}
+
+func TestEvery_ErrQueryFailsFast(t *testing.T) {
+	rule := Every{Rules: QueryRules{".bad[": String{}}}
+	n := tree.Map{"arr": tree.A(
+		tree.Map{"x": tree.V(1)},
+		tree.Map{"x": tree.V(2)},
+		tree.Map{"x": tree.V(3)},
+	)}
+	err := Validate(n, QueryRules{".arr": rule})
+	var eq *ErrQuery
+	if !errors.As(err, &eq) {
+		t.Fatalf("got %T (%v); want *ErrQuery", err, err)
+	}
+	// Same malformed rule fires on every element; fail-fast must return only one.
+	if got := strings.Count(err.Error(), "query "); got != 1 {
+		t.Errorf("query-error count = %d; want 1 (fail-fast)", got)
+	}
+}
+
+// checkErrs asserts that err either is nil (when wantErrs is empty) or
+// contains every substring in wantErrs. Shared by the test files in
+// this package.
+func checkErrs(t *testing.T, err error, wantErrs []string) {
+	t.Helper()
+	if len(wantErrs) == 0 {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("got nil; want error containing %v", wantErrs)
+	}
+	for _, want := range wantErrs {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- New `tree/schema` subpackage: validates a `tree.Node` against a `QueryRules` map (each entry pairs a tree query with a `Rule`). Built-ins cover presence, composition, leaf types, and an `Every` composite for per-element validation; `ParseQueryRules` loads the same rules from YAML/JSON via a pluggable `Registry`.
- `ValidateWithPrefix(n, rules, prefix)` is exported so custom composite rules (dispatch-style, e.g. fasthttpd's `HandlerDispatch`) can re-apply a rule set to a subtree without manually rewrapping errors.
- Malformed rule queries surface as `*ErrQuery` via fail-fast — a bug in the rules definition rather than a data violation — so callers can `errors.As` to distinguish "rules are broken" from "data is invalid".
- Documentation split: `schema/doc.go` is the API overview (renders on pkg.go.dev); `docs/schema.md` is the scenario/cookbook guide (nested bookstore example, `[]` vs `Every`, filter-query caveat, YAML spec reference, custom-rule and dispatch cookbooks, `*ErrQuery` handling). README gets a short Schema section pointing at both.

## Test plan

- [x] `go test ./schema/...` passes (covers `Validate`, `ValidateWithPrefix`, `Every`, YAML/JSON loading, `*ErrQuery` fail-fast, nested bookstore scenario via the shared `testdata.StoreJSON` fixture).
- [x] `go vet ./...` clean.
- [x] pkg.go.dev rendering of `schema/doc.go` — section headings and type cross-links resolve.
- [x] `docs/schema.md` renders on GitHub; internal section anchors and the pkg.go.dev jump-list links all resolve.
- [x] README Schema section: ToC entry, Features bullet, and the block between Edit and tq all render.