### PR TITLE
refactor(tree): Move IntPtr/Int64Ptr/Float64Ptr to tree, deprecate schema copies

### DIFF
--- a/schema/rules.go
+++ b/schema/rules.go
@@ -24,18 +24,20 @@ func Required(r Rule) Rule {
 	return And{Require{}, r}
 }
 
-// IntPtr, Int64Ptr, and Float64Ptr return a pointer to v. They are
-// convenience helpers for constructing pointer-valued rule fields
-// (String.MinLen, Int.Min, Float.Max, etc.) inline.
-
 // IntPtr returns a pointer to v.
-func IntPtr(v int) *int { return &v }
+//
+// Deprecated: Use [tree.IntPtr].
+func IntPtr(v int) *int { return tree.IntPtr(v) }
 
 // Int64Ptr returns a pointer to v.
-func Int64Ptr(v int64) *int64 { return &v }
+//
+// Deprecated: Use [tree.Int64Ptr].
+func Int64Ptr(v int64) *int64 { return tree.Int64Ptr(v) }
 
 // Float64Ptr returns a pointer to v.
-func Float64Ptr(v float64) *float64 { return &v }
+//
+// Deprecated: Use [tree.Float64Ptr].
+func Float64Ptr(v float64) *float64 { return tree.Float64Ptr(v) }
 
 // Require fires an error when the node is tree.Nil (query matched
 // nothing). It is the only rule that treats Nil as a violation.

--- a/util.go
+++ b/util.go
@@ -15,6 +15,19 @@ func V(v any) Node {
 	return ToValue(v)
 }
 
+// IntPtr, Int64Ptr, and Float64Ptr return a pointer to v. They are
+// convenience helpers for constructing pointer-valued struct fields
+// (e.g. ArrayRangeQuery.From, schema rule bounds) inline.
+
+// IntPtr returns a pointer to v.
+func IntPtr(v int) *int { return &v }
+
+// Int64Ptr returns a pointer to v.
+func Int64Ptr(v int64) *int64 { return &v }
+
+// Float64Ptr returns a pointer to v.
+func Float64Ptr(v float64) *float64 { return &v }
+
 // A is a short alias for [ToArrayValues]. It pairs with [V] for concise
 // construction of arrays:
 //


### PR DESCRIPTION
## Summary

- Move `IntPtr`, `Int64Ptr`, `Float64Ptr` from `schema` to the parent `tree` package
- Replace the original definitions in `schema` with thin wrappers calling `tree.X`, marked `Deprecated`
- Motivation: an upcoming `ArrayRangeQuery` struct migration (separate stacked PR) introduces pointer-valued public fields in `tree`, and the helpers belong with the type they construct rather than only in `schema`

## Compatibility

- `schema.IntPtr` / `schema.Int64Ptr` / `schema.Float64Ptr` still work; only marked deprecated for now
- Removal can be considered at a future major bump

## Test plan

- [x] `go test ./...` passes