### PR TITLE
test: Standardize all tests on testCases/tc/caseName with t.Run

### DIFF
--- a/color_test.go
+++ b/color_test.go
@@ -7,40 +7,33 @@ import (
 )
 
 func TestOutputColorJSON(t *testing.T) {
-	tests := []struct {
-		n    Node
-		want string
-	}{
-		{
-			n: Map{
-				"num":  ToValue(1),
-				"str":  ToValue("2"),
-				"bool": ToValue(true),
-				"null": Nil,
-			},
-			want: "{\n  \x1b[1;34m\"bool\"\x1b[0m: true,\n  \x1b[1;34m\"null\"\x1b[0m: \x1b[1;30mnull\x1b[0m,\n  \x1b[1;34m\"num\"\x1b[0m: 1,\n  \x1b[1;34m\"str\"\x1b[0m: \x1b[0;32m\"2\"\x1b[0m\n}\n",
-		},
+	n := Map{
+		"num":  ToValue(1),
+		"str":  ToValue("2"),
+		"bool": ToValue(true),
+		"null": Nil,
 	}
-	for i, test := range tests {
-		out := new(bytes.Buffer)
-		err := OutputColorJSON(out, test.n)
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		if got := out.String(); got != test.want {
-			t.Errorf("tests[%d] got %q; want %q\n%s", i, got, test.want, test.want)
-		}
+	want := "{\n  \x1b[1;34m\"bool\"\x1b[0m: true,\n  \x1b[1;34m\"null\"\x1b[0m: \x1b[1;30mnull\x1b[0m,\n  \x1b[1;34m\"num\"\x1b[0m: 1,\n  \x1b[1;34m\"str\"\x1b[0m: \x1b[0;32m\"2\"\x1b[0m\n}\n"
+
+	out := new(bytes.Buffer)
+	if err := OutputColorJSON(out, n); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != want {
+		t.Errorf("got %q; want %q\n%s", got, want, want)
 	}
 }
 
 func TestEncodeJSON(t *testing.T) {
-	tests := []struct {
-		e    *ColorEncoder
-		n    Node
-		want string
+	testCases := []struct {
+		caseName string
+		e        *ColorEncoder
+		n        Node
+		want     string
 	}{
 		{
-			e: &ColorEncoder{IndentSize: 4, NoColor: true},
+			caseName: "Map with Array, Nil and nil",
+			e:        &ColorEncoder{IndentSize: 4, NoColor: true},
 			n: Map{
 				"a": ToValue(1),
 				"b": Array{
@@ -61,59 +54,54 @@ func TestEncodeJSON(t *testing.T) {
 }
 `,
 		}, {
-			e:    &ColorEncoder{IndentSize: 2, NoColor: true},
-			n:    ToValue("\"\n\r\t"),
-			want: "\"\\\"\\n\\r\\t\"\n",
+			caseName: "string with control char escapes",
+			e:        &ColorEncoder{IndentSize: 2, NoColor: true},
+			n:        ToValue("\"\n\r\t"),
+			want:     "\"\\\"\\n\\r\\t\"\n",
 		},
 	}
-	for i, test := range tests {
-		out := new(bytes.Buffer)
-		test.e.Out = out
-		err := test.e.EncodeJSON(test.n)
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		if got := out.String(); got != test.want {
-			t.Errorf("tests[%d] got %q; want %q\n%s", i, got, test.want, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			tc.e.Out = out
+			if err := tc.e.EncodeJSON(tc.n); err != nil {
+				t.Fatal(err)
+			}
+			if got := out.String(); got != tc.want {
+				t.Errorf("got %q; want %q\n%s", got, tc.want, tc.want)
+			}
+		})
 	}
 }
 
 func TestOutputColorYAML(t *testing.T) {
-	tests := []struct {
-		n    Node
-		want string
-	}{
-		{
-			n: Map{
-				"num":  ToValue(1),
-				"str":  ToValue("2"),
-				"bool": ToValue(true),
-				"null": Nil,
-			},
-			want: "\x1b[1;34mbool\x1b[0m: true\n\x1b[1;34mnull\x1b[0m: \x1b[1;30mnull\x1b[0m\n\x1b[1;34mnum\x1b[0m: 1\n\x1b[1;34mstr\x1b[0m: \x1b[0;32m\"2\"\x1b[0m\n",
-		},
+	n := Map{
+		"num":  ToValue(1),
+		"str":  ToValue("2"),
+		"bool": ToValue(true),
+		"null": Nil,
 	}
-	for i, test := range tests {
-		out := new(bytes.Buffer)
-		err := OutputColorYAML(out, test.n)
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		if got := out.String(); got != test.want {
-			t.Errorf("tests[%d] got %q; want %q\n%s", i, got, test.want, test.want)
-		}
+	want := "\x1b[1;34mbool\x1b[0m: true\n\x1b[1;34mnull\x1b[0m: \x1b[1;30mnull\x1b[0m\n\x1b[1;34mnum\x1b[0m: 1\n\x1b[1;34mstr\x1b[0m: \x1b[0;32m\"2\"\x1b[0m\n"
+
+	out := new(bytes.Buffer)
+	if err := OutputColorYAML(out, n); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != want {
+		t.Errorf("got %q; want %q\n%s", got, want, want)
 	}
 }
 
 func TestEncodeYAML(t *testing.T) {
-	tests := []struct {
-		e    *ColorEncoder
-		n    Node
-		want string
+	testCases := []struct {
+		caseName string
+		e        *ColorEncoder
+		n        Node
+		want     string
 	}{
 		{
-			e: &ColorEncoder{IndentSize: 2, NoColor: true},
+			caseName: "Map with Array, Nil and nil",
+			e:        &ColorEncoder{IndentSize: 2, NoColor: true},
 			n: Map{
 				"a": ToValue(1),
 				"b": Array{
@@ -131,7 +119,8 @@ c: null
 d: null
 `,
 		}, {
-			e: &ColorEncoder{IndentSize: 2, NoColor: true},
+			caseName: "trailing newline triggers literal block",
+			e:        &ColorEncoder{IndentSize: 2, NoColor: true},
 			n: Map{
 				"a": ToValue("line1\nline2\n"),
 			},
@@ -140,7 +129,8 @@ d: null
   line2
 `,
 		}, {
-			e: &ColorEncoder{IndentSize: 2, NoColor: true},
+			caseName: "no trailing newline uses literal strip",
+			e:        &ColorEncoder{IndentSize: 2, NoColor: true},
 			n: Map{
 				"a": ToValue("line1\nline2"),
 			},
@@ -149,7 +139,8 @@ d: null
   line2
 `,
 		}, {
-			e: &ColorEncoder{IndentSize: 2, NoColor: true},
+			caseName: "Array of mixed types",
+			e:        &ColorEncoder{IndentSize: 2, NoColor: true},
 			n: Array{
 				ToValue(1),
 				Map{
@@ -170,16 +161,17 @@ d: null
 `,
 		},
 	}
-	for i, test := range tests {
-		out := new(bytes.Buffer)
-		test.e.Out = out
-		err := test.e.EncodeYAML(test.n)
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		if got := out.String(); got != test.want {
-			t.Errorf("tests[%d] got %q; want %q\n%s", i, got, test.want, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			tc.e.Out = out
+			if err := tc.e.EncodeYAML(tc.n); err != nil {
+				t.Fatal(err)
+			}
+			if got := out.String(); got != tc.want {
+				t.Errorf("got %q; want %q\n%s", got, tc.want, tc.want)
+			}
+		})
 	}
 }
 

--- a/edit_test.go
+++ b/edit_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func Test_Edit(t *testing.T) {
+func TestEdit(t *testing.T) {
 	testCases := []struct {
 		caseName string
 		n        Node
@@ -697,7 +697,7 @@ func Test_Edit(t *testing.T) {
 	}
 }
 
-func Test_Edit_resolveSelectStep_SelectorError(t *testing.T) {
+func TestEditResolveSelectStepSelectorError(t *testing.T) {
 	selector := &testSelectorDelegator{
 		matchesFunc: func(Node) (bool, error) {
 			return false, errors.New("selector boom")

--- a/json_test.go
+++ b/json_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mojatter/tree/internal/testdata"
 )
 
-func Test_MarshalJSON(t *testing.T) {
+func TestMarshalJSON(t *testing.T) {
 	want := `{"a":["1",2,true,null,null]}`
 	n := Map{
 		"a": Array{
@@ -29,7 +29,7 @@ func Test_MarshalJSON(t *testing.T) {
 	}
 }
 
-func Test_Map_MarshalJSON(t *testing.T) {
+func TestMapMarshalJSON(t *testing.T) {
 	want := `{"a":["1",2,true]}`
 	n := Map{
 		"a": Array{
@@ -47,7 +47,7 @@ func Test_Map_MarshalJSON(t *testing.T) {
 	}
 }
 
-func Test_Array_MarshalJSON(t *testing.T) {
+func TestArrayMarshalJSON(t *testing.T) {
 	want := `["1",2,true]`
 	n := Array{
 		StringValue("1"),
@@ -63,7 +63,7 @@ func Test_Array_MarshalJSON(t *testing.T) {
 	}
 }
 
-func Test_DecodeJSON_Errors(t *testing.T) {
+func TestDecodeJSONErrors(t *testing.T) {
 	tests := []struct {
 		data   []byte
 		errstr string
@@ -91,7 +91,7 @@ func Test_DecodeJSON_Errors(t *testing.T) {
 	}
 }
 
-func Test_UnmarshalJSON(t *testing.T) {
+func TestUnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		want Node
 		data string
@@ -152,7 +152,7 @@ func Test_UnmarshalJSON(t *testing.T) {
 	}
 }
 
-func Test_Map_UnmarshalJSON(t *testing.T) {
+func TestMapUnmarshalJSON(t *testing.T) {
 	want := Map{
 		"a": NumberValue(1),
 		"b": BoolValue(true),
@@ -168,7 +168,7 @@ func Test_Map_UnmarshalJSON(t *testing.T) {
 	}
 }
 
-func Test_Array_UnmarshalJSON(t *testing.T) {
+func TestArrayUnmarshalJSON(t *testing.T) {
 	want := Array{
 		StringValue("1"),
 		NumberValue(2),
@@ -184,7 +184,7 @@ func Test_Array_UnmarshalJSON(t *testing.T) {
 	}
 }
 
-func Test_MarshalViaJSON(t *testing.T) {
+func TestMarshalViaJSON(t *testing.T) {
 	tests := []struct {
 		v    any
 		want Node
@@ -233,7 +233,7 @@ func Test_MarshalViaJSON(t *testing.T) {
 	}
 }
 
-func Test_UnmarshalViaJSON(t *testing.T) {
+func TestUnmarshalViaJSON(t *testing.T) {
 	m := Map{
 		"id":     ToValue(1),
 		"name":   ToValue("Reds"),

--- a/json_test.go
+++ b/json_test.go
@@ -29,75 +29,89 @@ func TestMarshalJSON(t *testing.T) {
 	}
 }
 
-func TestMapMarshalJSON(t *testing.T) {
-	want := `{"a":["1",2,true]}`
-	n := Map{
-		"a": Array{
-			StringValue("1"),
-			NumberValue(2),
-			BoolValue(true),
+func TestNodeMarshalJSON(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		n        Node
+		want     string
+	}{
+		{
+			caseName: "Map",
+			n: Map{
+				"a": Array{
+					StringValue("1"),
+					NumberValue(2),
+					BoolValue(true),
+				},
+			},
+			want: `{"a":["1",2,true]}`,
+		},
+		{
+			caseName: "Array",
+			n: Array{
+				StringValue("1"),
+				NumberValue(2),
+				BoolValue(true),
+			},
+			want: `["1",2,true]`,
 		},
 	}
-	got, err := json.Marshal(n)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != want {
-		t.Errorf("got %s; want %s", string(got), want)
-	}
-}
-
-func TestArrayMarshalJSON(t *testing.T) {
-	want := `["1",2,true]`
-	n := Array{
-		StringValue("1"),
-		NumberValue(2),
-		BoolValue(true),
-	}
-	got, err := json.Marshal(n)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != want {
-		t.Errorf("got %s; want %s", string(got), want)
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got, err := json.Marshal(tc.n)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %s; want %s", string(got), tc.want)
+			}
+		})
 	}
 }
 
 func TestDecodeJSONErrors(t *testing.T) {
-	tests := []struct {
-		data   []byte
-		errstr string
+	testCases := []struct {
+		caseName string
+		data     []byte
+		errstr   string
 	}{
 		{
-			data:   []byte(`"`),
-			errstr: "unexpected EOF",
+			caseName: "unterminated string",
+			data:     []byte(`"`),
+			errstr:   "unexpected EOF",
 		}, {
-			data:   []byte(`}`),
-			errstr: "invalid character '}' looking for beginning of value",
+			caseName: "stray closing brace",
+			data:     []byte(`}`),
+			errstr:   "invalid character '}' looking for beginning of value",
 		}, {
-			data:   []byte("{\n1"),
-			errstr: `invalid character '1'`,
+			caseName: "invalid character after open brace",
+			data:     []byte("{\n1"),
+			errstr:   `invalid character '1'`,
 		},
 	}
-	for i, test := range tests {
-		dec := json.NewDecoder(bytes.NewReader(test.data))
-		_, err := DecodeJSON(dec)
-		if err == nil {
-			t.Fatalf("tests[%d] no error", i)
-		}
-		if err.Error() != test.errstr {
-			t.Errorf("tests[%d] got %s; want %s", i, err.Error(), test.errstr)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			dec := json.NewDecoder(bytes.NewReader(tc.data))
+			_, err := DecodeJSON(dec)
+			if err == nil {
+				t.Fatal("no error")
+			}
+			if err.Error() != tc.errstr {
+				t.Errorf("got %s; want %s", err.Error(), tc.errstr)
+			}
+		})
 	}
 }
 
 func TestUnmarshalJSON(t *testing.T) {
-	tests := []struct {
-		want Node
-		data string
+	testCases := []struct {
+		caseName string
+		data     string
+		want     Node
 	}{
 		{
-			data: `{"a":1,"b":true,"c":null,"d":["1",2,true],"e":{"x":"x"}}`,
+			caseName: "Map with nested Array and Map",
+			data:     `{"a":1,"b":true,"c":null,"d":["1",2,true],"e":{"x":"x"}}`,
 			want: Map{
 				"a": NumberValue(1),
 				"b": BoolValue(true),
@@ -112,7 +126,8 @@ func TestUnmarshalJSON(t *testing.T) {
 				},
 			},
 		}, {
-			data: `["1",2,true,null,{"a":1,"b":true,"c":null},["x"]]`,
+			caseName: "Array with nested Map and Array",
+			data:     `["1",2,true,null,{"a":1,"b":true,"c":null},["x"]]`,
 			want: Array{
 				StringValue("1"),
 				NumberValue(2),
@@ -127,28 +142,22 @@ func TestUnmarshalJSON(t *testing.T) {
 					StringValue("x"),
 				},
 			},
-		}, {
-			data: `1`,
-			want: NumberValue(1),
-		}, {
-			data: `"str"`,
-			want: StringValue("str"),
-		}, {
-			data: `true`,
-			want: BoolValue(true),
-		}, {
-			data: `null`,
-			want: Nil,
 		},
+		{caseName: "NumberValue", data: `1`, want: NumberValue(1)},
+		{caseName: "StringValue", data: `"str"`, want: StringValue("str")},
+		{caseName: "BoolValue", data: `true`, want: BoolValue(true)},
+		{caseName: "Nil", data: `null`, want: Nil},
 	}
-	for i, test := range tests {
-		got, err := UnmarshalJSON([]byte(test.data))
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] got %#v; want %#v", i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got, err := UnmarshalJSON([]byte(tc.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !Equal(got, tc.want) {
+				t.Errorf("got %#v; want %#v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -163,7 +172,7 @@ func TestMapUnmarshalJSON(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !Equal(got, want) {
 		t.Errorf("got %#v; want %#v", got, want)
 	}
 }
@@ -179,17 +188,19 @@ func TestArrayUnmarshalJSON(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !Equal(got, want) {
 		t.Errorf("got %#v; want %#v", got, want)
 	}
 }
 
 func TestMarshalViaJSON(t *testing.T) {
-	tests := []struct {
-		v    any
-		want Node
+	testCases := []struct {
+		caseName string
+		v        any
+		want     Node
 	}{
 		{
+			caseName: "struct",
 			v: struct {
 				ID     int      `json:"id"`
 				Name   string   `json:"name"`
@@ -204,32 +215,23 @@ func TestMarshalViaJSON(t *testing.T) {
 				"name":   ToValue("Reds"),
 				"colors": ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 			},
-		}, {
-			v:    "str",
-			want: StringValue("str"),
-		}, {
-			v:    true,
-			want: BoolValue(true),
-		}, {
-			v:    1,
-			want: NumberValue(1),
-		}, {
-			v:    nil,
-			want: Nil,
-		}, {
-			v:    BoolValue(true),
-			want: BoolValue(true),
 		},
+		{caseName: "string", v: "str", want: StringValue("str")},
+		{caseName: "bool", v: true, want: BoolValue(true)},
+		{caseName: "int", v: 1, want: NumberValue(1)},
+		{caseName: "nil", v: nil, want: Nil},
+		{caseName: "BoolValue passthrough", v: BoolValue(true), want: BoolValue(true)},
 	}
-
-	for i, test := range tests {
-		got, err := MarshalViaJSON(test.v)
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] got %#v; want %#v", i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got, err := MarshalViaJSON(tc.v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !Equal(got, tc.want) {
+				t.Errorf("got %#v; want %#v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,254 +1,290 @@
 package tree
 
 import (
-	"reflect"
 	"testing"
 )
 
 func TestMergeOption(t *testing.T) {
-	tests := []struct {
-		is   func() bool
-		want bool
+	overrideMapAppend := MergeOptionOverrideMap | MergeOptionAppend
+
+	testCases := []struct {
+		caseName string
+		is       func() bool
+		want     bool
 	}{
-		{is: MergeOptionDefault.isOverrideMap, want: false},
-		{is: MergeOptionDefault.isOverrideArray, want: false},
-		{is: MergeOptionDefault.isOverrideValue, want: false},
-		{is: MergeOptionDefault.isReplaceMap, want: false},
-		{is: MergeOptionDefault.isReplaceArray, want: false},
-		{is: MergeOptionDefault.isReplaceValue, want: false},
-		{is: MergeOptionDefault.isAppend, want: false},
-		{is: MergeOptionDefault.isSlurp, want: false},
-		{is: MergeOptionOverrideMap.isOverrideMap, want: true},
-		{is: MergeOptionOverrideMap.isOverrideArray, want: false},
-		{is: MergeOptionOverrideMap.isOverrideValue, want: true},
-		{is: MergeOptionOverrideMap.isReplaceMap, want: false},
-		{is: MergeOptionOverrideMap.isReplaceArray, want: false},
-		{is: MergeOptionOverrideMap.isReplaceValue, want: false},
-		{is: MergeOptionOverrideMap.isAppend, want: false},
-		{is: MergeOptionOverrideMap.isSlurp, want: false},
-		{is: MergeOptionOverrideArray.isOverrideMap, want: false},
-		{is: MergeOptionOverrideArray.isOverrideArray, want: true},
-		{is: MergeOptionOverrideArray.isOverrideValue, want: true},
-		{is: MergeOptionOverrideArray.isReplaceMap, want: false},
-		{is: MergeOptionOverrideArray.isReplaceArray, want: false},
-		{is: MergeOptionOverrideArray.isReplaceValue, want: false},
-		{is: MergeOptionOverrideArray.isAppend, want: false},
-		{is: MergeOptionOverrideArray.isSlurp, want: false},
-		{is: MergeOptionOverride.isOverrideMap, want: true},
-		{is: MergeOptionOverride.isOverrideArray, want: true},
-		{is: MergeOptionOverride.isOverrideValue, want: true},
-		{is: MergeOptionOverride.isReplaceMap, want: false},
-		{is: MergeOptionOverride.isReplaceArray, want: false},
-		{is: MergeOptionOverride.isReplaceValue, want: false},
-		{is: MergeOptionOverride.isAppend, want: false},
-		{is: MergeOptionOverride.isSlurp, want: false},
-		{is: MergeOptionReplaceMap.isOverrideMap, want: false},
-		{is: MergeOptionReplaceMap.isOverrideArray, want: false},
-		{is: MergeOptionReplaceMap.isOverrideValue, want: false},
-		{is: MergeOptionReplaceMap.isReplaceMap, want: true},
-		{is: MergeOptionReplaceMap.isReplaceArray, want: false},
-		{is: MergeOptionReplaceMap.isReplaceValue, want: true},
-		{is: MergeOptionReplaceMap.isAppend, want: false},
-		{is: MergeOptionReplaceMap.isSlurp, want: false},
-		{is: MergeOptionReplaceArray.isOverrideMap, want: false},
-		{is: MergeOptionReplaceArray.isOverrideArray, want: false},
-		{is: MergeOptionReplaceArray.isOverrideValue, want: false},
-		{is: MergeOptionReplaceArray.isReplaceMap, want: false},
-		{is: MergeOptionReplaceArray.isReplaceArray, want: true},
-		{is: MergeOptionReplaceArray.isReplaceValue, want: true},
-		{is: MergeOptionReplaceArray.isAppend, want: false},
-		{is: MergeOptionReplaceArray.isSlurp, want: false},
-		{is: MergeOptionReplace.isOverrideMap, want: false},
-		{is: MergeOptionReplace.isOverrideArray, want: false},
-		{is: MergeOptionReplace.isOverrideValue, want: false},
-		{is: MergeOptionReplace.isReplaceMap, want: true},
-		{is: MergeOptionReplace.isReplaceArray, want: true},
-		{is: MergeOptionReplace.isReplaceValue, want: true},
-		{is: MergeOptionReplace.isAppend, want: false},
-		{is: MergeOptionReplace.isSlurp, want: false},
-		{is: MergeOptionAppend.isOverrideMap, want: false},
-		{is: MergeOptionAppend.isOverrideArray, want: false},
-		{is: MergeOptionAppend.isOverrideValue, want: false},
-		{is: MergeOptionAppend.isReplaceMap, want: false},
-		{is: MergeOptionAppend.isReplaceArray, want: false},
-		{is: MergeOptionAppend.isReplaceValue, want: false},
-		{is: MergeOptionAppend.isAppend, want: true},
-		{is: MergeOptionAppend.isSlurp, want: false},
-		{is: MergeOptionSlurp.isOverrideMap, want: false},
-		{is: MergeOptionSlurp.isOverrideArray, want: false},
-		{is: MergeOptionSlurp.isOverrideValue, want: false},
-		{is: MergeOptionSlurp.isReplaceMap, want: false},
-		{is: MergeOptionSlurp.isReplaceArray, want: false},
-		{is: MergeOptionSlurp.isReplaceValue, want: false},
-		{is: MergeOptionSlurp.isAppend, want: false},
-		{is: MergeOptionSlurp.isSlurp, want: true},
-		{is: (MergeOptionOverrideMap | MergeOptionAppend).isOverrideMap, want: true},
-		{is: (MergeOptionOverrideMap | MergeOptionAppend).isOverrideArray, want: false},
-		{is: (MergeOptionOverrideMap | MergeOptionAppend).isOverrideValue, want: true},
-		{is: (MergeOptionOverrideMap | MergeOptionAppend).isReplaceMap, want: false},
-		{is: (MergeOptionOverrideMap | MergeOptionAppend).isReplaceArray, want: false},
-		{is: (MergeOptionOverrideMap | MergeOptionAppend).isReplaceValue, want: false},
-		{is: (MergeOptionOverrideMap | MergeOptionAppend).isAppend, want: true},
-		{is: (MergeOptionOverrideMap | MergeOptionAppend).isSlurp, want: false},
+		{"Default.isOverrideMap", MergeOptionDefault.isOverrideMap, false},
+		{"Default.isOverrideArray", MergeOptionDefault.isOverrideArray, false},
+		{"Default.isOverrideValue", MergeOptionDefault.isOverrideValue, false},
+		{"Default.isReplaceMap", MergeOptionDefault.isReplaceMap, false},
+		{"Default.isReplaceArray", MergeOptionDefault.isReplaceArray, false},
+		{"Default.isReplaceValue", MergeOptionDefault.isReplaceValue, false},
+		{"Default.isAppend", MergeOptionDefault.isAppend, false},
+		{"Default.isSlurp", MergeOptionDefault.isSlurp, false},
+		{"OverrideMap.isOverrideMap", MergeOptionOverrideMap.isOverrideMap, true},
+		{"OverrideMap.isOverrideArray", MergeOptionOverrideMap.isOverrideArray, false},
+		{"OverrideMap.isOverrideValue", MergeOptionOverrideMap.isOverrideValue, true},
+		{"OverrideMap.isReplaceMap", MergeOptionOverrideMap.isReplaceMap, false},
+		{"OverrideMap.isReplaceArray", MergeOptionOverrideMap.isReplaceArray, false},
+		{"OverrideMap.isReplaceValue", MergeOptionOverrideMap.isReplaceValue, false},
+		{"OverrideMap.isAppend", MergeOptionOverrideMap.isAppend, false},
+		{"OverrideMap.isSlurp", MergeOptionOverrideMap.isSlurp, false},
+		{"OverrideArray.isOverrideMap", MergeOptionOverrideArray.isOverrideMap, false},
+		{"OverrideArray.isOverrideArray", MergeOptionOverrideArray.isOverrideArray, true},
+		{"OverrideArray.isOverrideValue", MergeOptionOverrideArray.isOverrideValue, true},
+		{"OverrideArray.isReplaceMap", MergeOptionOverrideArray.isReplaceMap, false},
+		{"OverrideArray.isReplaceArray", MergeOptionOverrideArray.isReplaceArray, false},
+		{"OverrideArray.isReplaceValue", MergeOptionOverrideArray.isReplaceValue, false},
+		{"OverrideArray.isAppend", MergeOptionOverrideArray.isAppend, false},
+		{"OverrideArray.isSlurp", MergeOptionOverrideArray.isSlurp, false},
+		{"Override.isOverrideMap", MergeOptionOverride.isOverrideMap, true},
+		{"Override.isOverrideArray", MergeOptionOverride.isOverrideArray, true},
+		{"Override.isOverrideValue", MergeOptionOverride.isOverrideValue, true},
+		{"Override.isReplaceMap", MergeOptionOverride.isReplaceMap, false},
+		{"Override.isReplaceArray", MergeOptionOverride.isReplaceArray, false},
+		{"Override.isReplaceValue", MergeOptionOverride.isReplaceValue, false},
+		{"Override.isAppend", MergeOptionOverride.isAppend, false},
+		{"Override.isSlurp", MergeOptionOverride.isSlurp, false},
+		{"ReplaceMap.isOverrideMap", MergeOptionReplaceMap.isOverrideMap, false},
+		{"ReplaceMap.isOverrideArray", MergeOptionReplaceMap.isOverrideArray, false},
+		{"ReplaceMap.isOverrideValue", MergeOptionReplaceMap.isOverrideValue, false},
+		{"ReplaceMap.isReplaceMap", MergeOptionReplaceMap.isReplaceMap, true},
+		{"ReplaceMap.isReplaceArray", MergeOptionReplaceMap.isReplaceArray, false},
+		{"ReplaceMap.isReplaceValue", MergeOptionReplaceMap.isReplaceValue, true},
+		{"ReplaceMap.isAppend", MergeOptionReplaceMap.isAppend, false},
+		{"ReplaceMap.isSlurp", MergeOptionReplaceMap.isSlurp, false},
+		{"ReplaceArray.isOverrideMap", MergeOptionReplaceArray.isOverrideMap, false},
+		{"ReplaceArray.isOverrideArray", MergeOptionReplaceArray.isOverrideArray, false},
+		{"ReplaceArray.isOverrideValue", MergeOptionReplaceArray.isOverrideValue, false},
+		{"ReplaceArray.isReplaceMap", MergeOptionReplaceArray.isReplaceMap, false},
+		{"ReplaceArray.isReplaceArray", MergeOptionReplaceArray.isReplaceArray, true},
+		{"ReplaceArray.isReplaceValue", MergeOptionReplaceArray.isReplaceValue, true},
+		{"ReplaceArray.isAppend", MergeOptionReplaceArray.isAppend, false},
+		{"ReplaceArray.isSlurp", MergeOptionReplaceArray.isSlurp, false},
+		{"Replace.isOverrideMap", MergeOptionReplace.isOverrideMap, false},
+		{"Replace.isOverrideArray", MergeOptionReplace.isOverrideArray, false},
+		{"Replace.isOverrideValue", MergeOptionReplace.isOverrideValue, false},
+		{"Replace.isReplaceMap", MergeOptionReplace.isReplaceMap, true},
+		{"Replace.isReplaceArray", MergeOptionReplace.isReplaceArray, true},
+		{"Replace.isReplaceValue", MergeOptionReplace.isReplaceValue, true},
+		{"Replace.isAppend", MergeOptionReplace.isAppend, false},
+		{"Replace.isSlurp", MergeOptionReplace.isSlurp, false},
+		{"Append.isOverrideMap", MergeOptionAppend.isOverrideMap, false},
+		{"Append.isOverrideArray", MergeOptionAppend.isOverrideArray, false},
+		{"Append.isOverrideValue", MergeOptionAppend.isOverrideValue, false},
+		{"Append.isReplaceMap", MergeOptionAppend.isReplaceMap, false},
+		{"Append.isReplaceArray", MergeOptionAppend.isReplaceArray, false},
+		{"Append.isReplaceValue", MergeOptionAppend.isReplaceValue, false},
+		{"Append.isAppend", MergeOptionAppend.isAppend, true},
+		{"Append.isSlurp", MergeOptionAppend.isSlurp, false},
+		{"Slurp.isOverrideMap", MergeOptionSlurp.isOverrideMap, false},
+		{"Slurp.isOverrideArray", MergeOptionSlurp.isOverrideArray, false},
+		{"Slurp.isOverrideValue", MergeOptionSlurp.isOverrideValue, false},
+		{"Slurp.isReplaceMap", MergeOptionSlurp.isReplaceMap, false},
+		{"Slurp.isReplaceArray", MergeOptionSlurp.isReplaceArray, false},
+		{"Slurp.isReplaceValue", MergeOptionSlurp.isReplaceValue, false},
+		{"Slurp.isAppend", MergeOptionSlurp.isAppend, false},
+		{"Slurp.isSlurp", MergeOptionSlurp.isSlurp, true},
+		{"OverrideMap|Append.isOverrideMap", overrideMapAppend.isOverrideMap, true},
+		{"OverrideMap|Append.isOverrideArray", overrideMapAppend.isOverrideArray, false},
+		{"OverrideMap|Append.isOverrideValue", overrideMapAppend.isOverrideValue, true},
+		{"OverrideMap|Append.isReplaceMap", overrideMapAppend.isReplaceMap, false},
+		{"OverrideMap|Append.isReplaceArray", overrideMapAppend.isReplaceArray, false},
+		{"OverrideMap|Append.isReplaceValue", overrideMapAppend.isReplaceValue, false},
+		{"OverrideMap|Append.isAppend", overrideMapAppend.isAppend, true},
+		{"OverrideMap|Append.isSlurp", overrideMapAppend.isSlurp, false},
 	}
-	for i, test := range tests {
-		if got := test.is(); got != test.want {
-			t.Errorf("tests[%d] got %v; want %v", i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got := tc.is(); got != tc.want {
+				t.Errorf("got %v; want %v", got, tc.want)
+			}
+		})
 	}
 }
 
 func TestMerge(t *testing.T) {
-	tests := []struct {
-		a    Node
-		b    Node
-		opts MergeOption
-		want Node
+	testCases := []struct {
+		caseName string
+		a        Node
+		b        Node
+		opts     MergeOption
+		want     Node
 	}{
 		{
-			a:    Map{"a": ToValue(1), "b": ToValue(2)},
-			b:    Map{"a": ToValue(3), "c": ToValue(4)},
-			want: Map{"a": ToValue(1), "b": ToValue(2), "c": ToValue(4)},
+			caseName: "Default Map merges new key",
+			a:        Map{"a": ToValue(1), "b": ToValue(2)},
+			b:        Map{"a": ToValue(3), "c": ToValue(4)},
+			want:     Map{"a": ToValue(1), "b": ToValue(2), "c": ToValue(4)},
 		}, {
-			a:    Map{"a": ToValue(1), "b": ToValue(2)},
-			b:    Nil,
-			want: Map{"a": ToValue(1), "b": ToValue(2)},
+			caseName: "Default Map vs Nil keeps a",
+			a:        Map{"a": ToValue(1), "b": ToValue(2)},
+			b:        Nil,
+			want:     Map{"a": ToValue(1), "b": ToValue(2)},
 		}, {
-			a:    ToArrayValues(1, 2),
-			b:    ToArrayValues(3, 4, 5),
-			want: ToArrayValues(1, 2, 5),
+			caseName: "Default Array overlays trailing",
+			a:        ToArrayValues(1, 2),
+			b:        ToArrayValues(3, 4, 5),
+			want:     ToArrayValues(1, 2, 5),
 		}, {
-			a:    ToArrayValues(1, 2, 3),
-			b:    ToArrayValues(4, 5),
-			want: ToArrayValues(1, 2, 3),
+			caseName: "Default Array longer a",
+			a:        ToArrayValues(1, 2, 3),
+			b:        ToArrayValues(4, 5),
+			want:     ToArrayValues(1, 2, 3),
 		}, {
-			a:    ToValue("a"),
-			b:    ToValue("b"),
-			want: ToValue("a"),
+			caseName: "Default Value keeps a",
+			a:        ToValue("a"),
+			b:        ToValue("b"),
+			want:     ToValue("a"),
 		}, {
-			a:    Map{"a": ToValue(1), "b": ToValue(2)},
-			b:    ToValue("c"),
-			want: Map{"a": ToValue(1), "b": ToValue(2)},
+			caseName: "Default Map vs Value keeps a",
+			a:        Map{"a": ToValue(1), "b": ToValue(2)},
+			b:        ToValue("c"),
+			want:     Map{"a": ToValue(1), "b": ToValue(2)},
 		}, {
-			a:    ToArrayValues("a"),
-			b:    ToValue("b"),
-			want: ToArrayValues("a"),
+			caseName: "Default Array vs Value keeps a",
+			a:        ToArrayValues("a"),
+			b:        ToValue("b"),
+			want:     ToArrayValues("a"),
 		}, {
-			a:    Map{"a": ToValue(1), "b": ToValue(2)},
-			b:    Map{"a": ToValue(3)},
-			opts: MergeOptionOverrideMap,
-			want: Map{"a": ToValue(3), "b": ToValue(2)},
+			caseName: "OverrideMap Map overlays existing key",
+			a:        Map{"a": ToValue(1), "b": ToValue(2)},
+			b:        Map{"a": ToValue(3)},
+			opts:     MergeOptionOverrideMap,
+			want:     Map{"a": ToValue(3), "b": ToValue(2)},
 		}, {
-			a:    Map{"a": ToValue(1), "b": ToValue(2)},
-			b:    Nil,
-			opts: MergeOptionOverrideMap,
-			want: Nil,
+			caseName: "OverrideMap Map vs Nil",
+			a:        Map{"a": ToValue(1), "b": ToValue(2)},
+			b:        Nil,
+			opts:     MergeOptionOverrideMap,
+			want:     Nil,
 		}, {
-			a:    ToValue("a"),
-			b:    ToValue("b"),
-			opts: MergeOptionOverrideMap,
-			want: ToValue("b"),
+			caseName: "OverrideMap Value override",
+			a:        ToValue("a"),
+			b:        ToValue("b"),
+			opts:     MergeOptionOverrideMap,
+			want:     ToValue("b"),
 		}, {
-			a:    Map{"a": ToValue(1), "b": ToValue(2), "c": ToValue(3)},
-			b:    Map{"a": ToValue(4), "b": ToArrayValues(5, 6), "d": ToValue(7)},
-			opts: MergeOptionOverrideMap,
-			want: Map{"a": ToValue(4), "b": ToArrayValues(5, 6), "c": ToValue(3), "d": ToValue(7)},
+			caseName: "OverrideMap mixed types",
+			a:        Map{"a": ToValue(1), "b": ToValue(2), "c": ToValue(3)},
+			b:        Map{"a": ToValue(4), "b": ToArrayValues(5, 6), "d": ToValue(7)},
+			opts:     MergeOptionOverrideMap,
+			want:     Map{"a": ToValue(4), "b": ToArrayValues(5, 6), "c": ToValue(3), "d": ToValue(7)},
 		}, {
-			a:    ToArrayValues(1, 2, 3),
-			b:    ToArrayValues(4, 5),
-			opts: MergeOptionOverrideArray,
-			want: ToArrayValues(4, 5, 3),
+			caseName: "OverrideArray shorter b",
+			a:        ToArrayValues(1, 2, 3),
+			b:        ToArrayValues(4, 5),
+			opts:     MergeOptionOverrideArray,
+			want:     ToArrayValues(4, 5, 3),
 		}, {
-			a:    ToArrayValues(1, 2, 3),
-			b:    ToArrayValues(4, 5, 6, 7),
-			opts: MergeOptionOverrideArray,
-			want: ToArrayValues(4, 5, 6, 7),
+			caseName: "OverrideArray longer b",
+			a:        ToArrayValues(1, 2, 3),
+			b:        ToArrayValues(4, 5, 6, 7),
+			opts:     MergeOptionOverrideArray,
+			want:     ToArrayValues(4, 5, 6, 7),
 		}, {
-			a:    ToValue("a"),
-			b:    ToValue("b"),
-			opts: MergeOptionOverrideArray,
-			want: ToValue("b"),
+			caseName: "OverrideArray Value override",
+			a:        ToValue("a"),
+			b:        ToValue("b"),
+			opts:     MergeOptionOverrideArray,
+			want:     ToValue("b"),
 		}, {
-			a:    Map{"a": ToValue(1), "b": ToValue(2)},
-			b:    Map{"a": ToValue(3)},
-			opts: MergeOptionOverride,
-			want: Map{"a": ToValue(3), "b": ToValue(2)},
+			caseName: "Override Map",
+			a:        Map{"a": ToValue(1), "b": ToValue(2)},
+			b:        Map{"a": ToValue(3)},
+			opts:     MergeOptionOverride,
+			want:     Map{"a": ToValue(3), "b": ToValue(2)},
 		}, {
-			a:    ToArrayValues(1, 2, 3),
-			b:    ToArrayValues(4, 5),
-			opts: MergeOptionOverride,
-			want: ToArrayValues(4, 5, 3),
+			caseName: "Override Array",
+			a:        ToArrayValues(1, 2, 3),
+			b:        ToArrayValues(4, 5),
+			opts:     MergeOptionOverride,
+			want:     ToArrayValues(4, 5, 3),
 		}, {
-			a:    ToValue("a"),
-			b:    ToValue("b"),
-			opts: MergeOptionOverride,
-			want: ToValue("b"),
+			caseName: "Override Value",
+			a:        ToValue("a"),
+			b:        ToValue("b"),
+			opts:     MergeOptionOverride,
+			want:     ToValue("b"),
 		}, {
-			a:    Map{"a": ToValue(1), "b": ToValue(2)},
-			b:    Map{"a": ToValue(3)},
-			opts: MergeOptionReplaceMap,
-			want: Map{"a": ToValue(3)},
+			caseName: "ReplaceMap Map",
+			a:        Map{"a": ToValue(1), "b": ToValue(2)},
+			b:        Map{"a": ToValue(3)},
+			opts:     MergeOptionReplaceMap,
+			want:     Map{"a": ToValue(3)},
 		}, {
-			a:    ToValue("a"),
-			b:    ToValue("b"),
-			opts: MergeOptionReplaceMap,
-			want: ToValue("b"),
+			caseName: "ReplaceMap Value first",
+			a:        ToValue("a"),
+			b:        ToValue("b"),
+			opts:     MergeOptionReplaceMap,
+			want:     ToValue("b"),
 		}, {
-			a:    ToValue("a"),
-			b:    ToValue("b"),
-			opts: MergeOptionReplaceMap,
-			want: ToValue("b"),
+			caseName: "ReplaceMap Value second",
+			a:        ToValue("a"),
+			b:        ToValue("b"),
+			opts:     MergeOptionReplaceMap,
+			want:     ToValue("b"),
 		}, {
-			a:    ToArrayValues(1, 2, 3),
-			b:    ToArrayValues(4, 5),
-			opts: MergeOptionReplaceArray,
-			want: ToArrayValues(4, 5),
+			caseName: "ReplaceArray Array",
+			a:        ToArrayValues(1, 2, 3),
+			b:        ToArrayValues(4, 5),
+			opts:     MergeOptionReplaceArray,
+			want:     ToArrayValues(4, 5),
 		}, {
-			a:    ToValue("a"),
-			b:    ToValue("b"),
-			opts: MergeOptionReplaceArray,
-			want: ToValue("b"),
+			caseName: "ReplaceArray Value",
+			a:        ToValue("a"),
+			b:        ToValue("b"),
+			opts:     MergeOptionReplaceArray,
+			want:     ToValue("b"),
 		}, {
-			a:    ToValue("a"),
-			b:    ToValue("b"),
-			opts: MergeOptionReplace,
-			want: ToValue("b"),
+			caseName: "Replace Value",
+			a:        ToValue("a"),
+			b:        ToValue("b"),
+			opts:     MergeOptionReplace,
+			want:     ToValue("b"),
 		}, {
-			a:    ToArrayValues(1, 2, 3),
-			b:    ToArrayValues(4, 5),
-			opts: MergeOptionReplace,
-			want: ToArrayValues(4, 5),
+			caseName: "Replace Array",
+			a:        ToArrayValues(1, 2, 3),
+			b:        ToArrayValues(4, 5),
+			opts:     MergeOptionReplace,
+			want:     ToArrayValues(4, 5),
 		}, {
-			a:    ToValue("a"),
-			b:    ToValue("b"),
-			opts: MergeOptionReplace,
-			want: ToValue("b"),
+			caseName: "Replace Value second",
+			a:        ToValue("a"),
+			b:        ToValue("b"),
+			opts:     MergeOptionReplace,
+			want:     ToValue("b"),
 		}, {
-			a:    ToArrayValues(1, 2, 3),
-			b:    ToArrayValues(4, 5),
-			opts: MergeOptionAppend,
-			want: ToArrayValues(1, 2, 3, 4, 5),
+			caseName: "Append Array",
+			a:        ToArrayValues(1, 2, 3),
+			b:        ToArrayValues(4, 5),
+			opts:     MergeOptionAppend,
+			want:     ToArrayValues(1, 2, 3, 4, 5),
 		}, {
-			a:    ToArrayValues(1, 2, 3),
-			b:    ToArrayValues(4, 5),
-			opts: MergeOptionSlurp,
-			want: ToArrayValues(1, 2, 3, 4, 5),
+			caseName: "Slurp Array Array",
+			a:        ToArrayValues(1, 2, 3),
+			b:        ToArrayValues(4, 5),
+			opts:     MergeOptionSlurp,
+			want:     ToArrayValues(1, 2, 3, 4, 5),
 		}, {
-			a:    ToArrayValues(1, 2, 3),
-			b:    ToValue(4),
-			opts: MergeOptionSlurp,
-			want: ToArrayValues(1, 2, 3, 4),
+			caseName: "Slurp Array Value",
+			a:        ToArrayValues(1, 2, 3),
+			b:        ToValue(4),
+			opts:     MergeOptionSlurp,
+			want:     ToArrayValues(1, 2, 3, 4),
 		}, {
-			a:    ToValue(1),
-			b:    ToValue(2),
-			opts: MergeOptionSlurp,
-			want: ToArrayValues(1, 2),
+			caseName: "Slurp Value Value",
+			a:        ToValue(1),
+			b:        ToValue(2),
+			opts:     MergeOptionSlurp,
+			want:     ToArrayValues(1, 2),
 		}, {
-			a:    Map{"a": ToValue(1)},
-			b:    Map{"a": ToValue(2)},
-			opts: MergeOptionSlurp,
-			want: Map{"a": ToArrayValues(1, 2)},
+			caseName: "Slurp Map Map",
+			a:        Map{"a": ToValue(1)},
+			b:        Map{"a": ToValue(2)},
+			opts:     MergeOptionSlurp,
+			want:     Map{"a": ToArrayValues(1, 2)},
 		}, {
+			caseName: "OverrideMap|Append nested",
 			a: Map{
 				"map":          Map{"a": ToValue(1), "b": ToValue(2)},
 				"array":        ToArrayValues(3, 4, 5),
@@ -266,6 +302,7 @@ func TestMerge(t *testing.T) {
 				"arrayOrValue": ToValue(12),
 			},
 		}, {
+			caseName: "Append|Slurp nested",
 			a: Map{
 				"map":          Map{"a": ToValue(1), "b": ToValue(2)},
 				"array":        ToArrayValues(3, 4, 5),
@@ -283,6 +320,7 @@ func TestMerge(t *testing.T) {
 				"arrayOrValue": ToArrayValues(6, 7, 8, 12),
 			},
 		}, {
+			caseName: "ReplaceMap|Append nested",
 			a: Map{
 				"map":   Map{"a": ToValue(1), "b": ToValue(2)},
 				"array": ToArrayValues(3, 4, 5),
@@ -298,17 +336,19 @@ func TestMerge(t *testing.T) {
 			},
 		},
 	}
-	for i, test := range tests {
-		a, b := CloneDeep(test.a), CloneDeep(test.b)
-		got := Merge(CloneDeep(test.a), CloneDeep(test.b), test.opts)
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf(`tests[%d]: unexpected %v; want %v`, i, got, test.want)
-		}
-		if !reflect.DeepEqual(a, test.a) {
-			t.Errorf(`tests[%d]: unexpected %v; want %v`, i, got, test.want)
-		}
-		if !reflect.DeepEqual(b, test.b) {
-			t.Errorf(`tests[%d]: unexpected %v; want %v`, i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			a, b := CloneDeep(tc.a), CloneDeep(tc.b)
+			got := Merge(CloneDeep(tc.a), CloneDeep(tc.b), tc.opts)
+			if !Equal(got, tc.want) {
+				t.Errorf("unexpected %v; want %v", got, tc.want)
+			}
+			if !Equal(a, tc.a) {
+				t.Errorf("a was mutated: %v; want %v", a, tc.a)
+			}
+			if !Equal(b, tc.b) {
+				t.Errorf("b was mutated: %v; want %v", b, tc.b)
+			}
+		})
 	}
 }

--- a/methodquery_test.go
+++ b/methodquery_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func Test_MethodQuery(t *testing.T) {
+func TestMethodQuery(t *testing.T) {
 	testCases := []struct {
 		caseName string
 		q        Query
@@ -279,7 +279,7 @@ func Test_MethodQuery(t *testing.T) {
 	}
 }
 
-func Test_NewMethodQuery(t *testing.T) {
+func TestNewMethodQuery(t *testing.T) {
 	testCases := []struct {
 		caseName string
 		method   string
@@ -424,7 +424,7 @@ func Test_NewMethodQuery(t *testing.T) {
 	}
 }
 
-func Test_RegisterNewMethodQueryFunc(t *testing.T) {
+func TestRegisterNewMethodQueryFunc(t *testing.T) {
 	// Save original state
 	methodQueryMux.Lock()
 	original := make(map[string]NewMethodQueryFunc)

--- a/node_test.go
+++ b/node_test.go
@@ -8,57 +8,59 @@ import (
 )
 
 func TestType(t *testing.T) {
-	tests := []struct {
-		typ  Type
-		is   func() bool
-		want bool
+	testCases := []struct {
+		caseName string
+		is       func() bool
+		want     bool
 	}{
-		{typ: TypeArray, is: TypeArray.IsArray, want: true},
-		{typ: TypeArray, is: TypeArray.IsMap, want: false},
-		{typ: TypeArray, is: TypeArray.IsValue, want: false},
-		{typ: TypeMap, is: TypeMap.IsArray, want: false},
-		{typ: TypeMap, is: TypeMap.IsMap, want: true},
-		{typ: TypeMap, is: TypeMap.IsValue, want: false},
-		{typ: TypeValue, is: TypeValue.IsArray, want: false},
-		{typ: TypeValue, is: TypeValue.IsMap, want: false},
-		{typ: TypeValue, is: TypeValue.IsValue, want: true},
-		{typ: TypeValue, is: TypeValue.IsNilValue, want: false},
-		{typ: TypeValue, is: TypeValue.IsStringValue, want: false},
-		{typ: TypeValue, is: TypeValue.IsBoolValue, want: false},
-		{typ: TypeValue, is: TypeValue.IsNumberValue, want: false},
-		{typ: TypeNilValue, is: TypeNilValue.IsArray, want: false},
-		{typ: TypeNilValue, is: TypeNilValue.IsMap, want: false},
-		{typ: TypeNilValue, is: TypeNilValue.IsValue, want: true},
-		{typ: TypeNilValue, is: TypeNilValue.IsNilValue, want: true},
-		{typ: TypeNilValue, is: TypeNilValue.IsStringValue, want: false},
-		{typ: TypeNilValue, is: TypeNilValue.IsBoolValue, want: false},
-		{typ: TypeNilValue, is: TypeNilValue.IsNumberValue, want: false},
-		{typ: TypeStringValue, is: TypeStringValue.IsArray, want: false},
-		{typ: TypeStringValue, is: TypeStringValue.IsMap, want: false},
-		{typ: TypeStringValue, is: TypeStringValue.IsValue, want: true},
-		{typ: TypeStringValue, is: TypeStringValue.IsNilValue, want: false},
-		{typ: TypeStringValue, is: TypeStringValue.IsStringValue, want: true},
-		{typ: TypeStringValue, is: TypeStringValue.IsBoolValue, want: false},
-		{typ: TypeStringValue, is: TypeStringValue.IsNumberValue, want: false},
-		{typ: TypeBoolValue, is: TypeBoolValue.IsArray, want: false},
-		{typ: TypeBoolValue, is: TypeBoolValue.IsMap, want: false},
-		{typ: TypeBoolValue, is: TypeBoolValue.IsValue, want: true},
-		{typ: TypeBoolValue, is: TypeBoolValue.IsNilValue, want: false},
-		{typ: TypeBoolValue, is: TypeBoolValue.IsStringValue, want: false},
-		{typ: TypeBoolValue, is: TypeBoolValue.IsBoolValue, want: true},
-		{typ: TypeBoolValue, is: TypeBoolValue.IsNumberValue, want: false},
-		{typ: TypeNumberValue, is: TypeNumberValue.IsArray, want: false},
-		{typ: TypeNumberValue, is: TypeNumberValue.IsMap, want: false},
-		{typ: TypeNumberValue, is: TypeNumberValue.IsValue, want: true},
-		{typ: TypeNumberValue, is: TypeNumberValue.IsNilValue, want: false},
-		{typ: TypeNumberValue, is: TypeNumberValue.IsStringValue, want: false},
-		{typ: TypeNumberValue, is: TypeNumberValue.IsBoolValue, want: false},
-		{typ: TypeNumberValue, is: TypeNumberValue.IsNumberValue, want: true},
+		{"TypeArray.IsArray", TypeArray.IsArray, true},
+		{"TypeArray.IsMap", TypeArray.IsMap, false},
+		{"TypeArray.IsValue", TypeArray.IsValue, false},
+		{"TypeMap.IsArray", TypeMap.IsArray, false},
+		{"TypeMap.IsMap", TypeMap.IsMap, true},
+		{"TypeMap.IsValue", TypeMap.IsValue, false},
+		{"TypeValue.IsArray", TypeValue.IsArray, false},
+		{"TypeValue.IsMap", TypeValue.IsMap, false},
+		{"TypeValue.IsValue", TypeValue.IsValue, true},
+		{"TypeValue.IsNilValue", TypeValue.IsNilValue, false},
+		{"TypeValue.IsStringValue", TypeValue.IsStringValue, false},
+		{"TypeValue.IsBoolValue", TypeValue.IsBoolValue, false},
+		{"TypeValue.IsNumberValue", TypeValue.IsNumberValue, false},
+		{"TypeNilValue.IsArray", TypeNilValue.IsArray, false},
+		{"TypeNilValue.IsMap", TypeNilValue.IsMap, false},
+		{"TypeNilValue.IsValue", TypeNilValue.IsValue, true},
+		{"TypeNilValue.IsNilValue", TypeNilValue.IsNilValue, true},
+		{"TypeNilValue.IsStringValue", TypeNilValue.IsStringValue, false},
+		{"TypeNilValue.IsBoolValue", TypeNilValue.IsBoolValue, false},
+		{"TypeNilValue.IsNumberValue", TypeNilValue.IsNumberValue, false},
+		{"TypeStringValue.IsArray", TypeStringValue.IsArray, false},
+		{"TypeStringValue.IsMap", TypeStringValue.IsMap, false},
+		{"TypeStringValue.IsValue", TypeStringValue.IsValue, true},
+		{"TypeStringValue.IsNilValue", TypeStringValue.IsNilValue, false},
+		{"TypeStringValue.IsStringValue", TypeStringValue.IsStringValue, true},
+		{"TypeStringValue.IsBoolValue", TypeStringValue.IsBoolValue, false},
+		{"TypeStringValue.IsNumberValue", TypeStringValue.IsNumberValue, false},
+		{"TypeBoolValue.IsArray", TypeBoolValue.IsArray, false},
+		{"TypeBoolValue.IsMap", TypeBoolValue.IsMap, false},
+		{"TypeBoolValue.IsValue", TypeBoolValue.IsValue, true},
+		{"TypeBoolValue.IsNilValue", TypeBoolValue.IsNilValue, false},
+		{"TypeBoolValue.IsStringValue", TypeBoolValue.IsStringValue, false},
+		{"TypeBoolValue.IsBoolValue", TypeBoolValue.IsBoolValue, true},
+		{"TypeBoolValue.IsNumberValue", TypeBoolValue.IsNumberValue, false},
+		{"TypeNumberValue.IsArray", TypeNumberValue.IsArray, false},
+		{"TypeNumberValue.IsMap", TypeNumberValue.IsMap, false},
+		{"TypeNumberValue.IsValue", TypeNumberValue.IsValue, true},
+		{"TypeNumberValue.IsNilValue", TypeNumberValue.IsNilValue, false},
+		{"TypeNumberValue.IsStringValue", TypeNumberValue.IsStringValue, false},
+		{"TypeNumberValue.IsBoolValue", TypeNumberValue.IsBoolValue, false},
+		{"TypeNumberValue.IsNumberValue", TypeNumberValue.IsNumberValue, true},
 	}
-	for i, test := range tests {
-		if got := test.is(); got != test.want {
-			t.Errorf("tests[%d] got %v; want %v", i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got := tc.is(); got != tc.want {
+				t.Errorf("got %v; want %v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -88,7 +90,8 @@ func TestTypeString(t *testing.T) {
 }
 
 func TestNode(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
+		caseName  string
 		n         Node
 		isNil     bool
 		t         Type
@@ -103,6 +106,7 @@ func TestNode(t *testing.T) {
 		findValue []Node
 	}{
 		{
+			caseName: "Map(nil)",
 			n:        Map(nil),
 			isNil:    true,
 			t:        TypeMap,
@@ -111,6 +115,7 @@ func TestNode(t *testing.T) {
 			v:        Nil,
 			getValue: Nil,
 		}, {
+			caseName: "Map empty",
 			n:        Map{},
 			t:        TypeMap,
 			m:        Map{},
@@ -118,6 +123,7 @@ func TestNode(t *testing.T) {
 			v:        Nil,
 			getValue: Nil,
 		}, {
+			caseName: "Array(nil)",
 			n:        Array(nil),
 			isNil:    true,
 			t:        TypeArray,
@@ -126,6 +132,7 @@ func TestNode(t *testing.T) {
 			v:        Nil,
 			getValue: Nil,
 		}, {
+			caseName: "Array empty",
 			n:        Array{},
 			t:        TypeArray,
 			m:        Map(nil),
@@ -133,6 +140,7 @@ func TestNode(t *testing.T) {
 			v:        Nil,
 			getValue: Nil,
 		}, {
+			caseName: "Nil",
 			n:        Nil,
 			isNil:    true,
 			t:        TypeNilValue,
@@ -141,6 +149,7 @@ func TestNode(t *testing.T) {
 			v:        Nil,
 			getValue: Nil,
 		}, {
+			caseName: "StringValue",
 			n:        StringValue("a"),
 			t:        TypeStringValue,
 			m:        Map(nil),
@@ -148,6 +157,7 @@ func TestNode(t *testing.T) {
 			v:        StringValue("a"),
 			getValue: Nil,
 		}, {
+			caseName: "BoolValue",
 			n:        BoolValue(true),
 			t:        TypeBoolValue,
 			m:        Map(nil),
@@ -155,6 +165,7 @@ func TestNode(t *testing.T) {
 			v:        BoolValue(true),
 			getValue: Nil,
 		}, {
+			caseName: "NumberValue",
 			n:        NumberValue(1),
 			t:        TypeNumberValue,
 			m:        Map(nil),
@@ -162,6 +173,7 @@ func TestNode(t *testing.T) {
 			v:        NumberValue(1),
 			getValue: Nil,
 		}, {
+			caseName: "Any wrapping Map(nil)",
 			n:        Any{Map(nil)},
 			isNil:    true,
 			t:        TypeMap,
@@ -171,268 +183,313 @@ func TestNode(t *testing.T) {
 			getValue: Nil,
 		},
 	}
-	for i, test := range tests {
-		n := test.n
-		if n.IsNil() != test.isNil {
-			t.Errorf("tests[%d] IsNil got %v; want %v", i, n.IsNil(), test.isNil)
-		}
-		if tt := n.Type(); tt != test.t {
-			t.Errorf("tests[%d] Type got %v; want %v", i, tt, test.t)
-		}
-		if aa := n.Array(); !reflect.DeepEqual(aa, test.a) {
-			t.Errorf("tests[%d] Array got %v; want %v", i, aa, test.a)
-		}
-		if mm := n.Map(); !reflect.DeepEqual(mm, test.m) {
-			t.Errorf("tests[%d] Map got %v; want %v", i, mm, test.m)
-		}
-		if vv := n.Value(); !reflect.DeepEqual(vv, test.v) {
-			t.Errorf("tests[%d] Value got %v; want %v", i, vv, test.v)
-		}
-		if had := n.Has(test.hasKeys...); had != test.hasValue {
-			t.Errorf("tests[%d] Has got %v; want %v", i, had, test.hasValue)
-		}
-		if got := n.Get(test.getKeys...); !reflect.DeepEqual(got, test.getValue) {
-			t.Errorf("tests[%d] Get got %v; want %v", i, got, test.getValue)
-		}
-		found, err := n.Find(test.findExpr)
-		if err != nil {
-			t.Errorf("tests[%d] failed to Find error %v", i, err)
-		}
-		if !reflect.DeepEqual(found, test.findValue) {
-			t.Errorf("tests[%d] Find got %v; want %v", i, found, test.findValue)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			n := tc.n
+			if n.IsNil() != tc.isNil {
+				t.Errorf("IsNil got %v; want %v", n.IsNil(), tc.isNil)
+			}
+			if tt := n.Type(); tt != tc.t {
+				t.Errorf("Type got %v; want %v", tt, tc.t)
+			}
+			if aa := n.Array(); !Equal(aa, tc.a) {
+				t.Errorf("Array got %v; want %v", aa, tc.a)
+			}
+			if mm := n.Map(); !Equal(mm, tc.m) {
+				t.Errorf("Map got %v; want %v", mm, tc.m)
+			}
+			if vv := n.Value(); !Equal(vv, tc.v) {
+				t.Errorf("Value got %v; want %v", vv, tc.v)
+			}
+			if had := n.Has(tc.hasKeys...); had != tc.hasValue {
+				t.Errorf("Has got %v; want %v", had, tc.hasValue)
+			}
+			if got := n.Get(tc.getKeys...); !Equal(got, tc.getValue) {
+				t.Errorf("Get got %v; want %v", got, tc.getValue)
+			}
+			found, err := n.Find(tc.findExpr)
+			if err != nil {
+				t.Errorf("failed to Find error %v", err)
+			}
+			if !Equal(Array(found), Array(tc.findValue)) {
+				t.Errorf("Find got %v; want %v", found, tc.findValue)
+			}
+		})
 	}
 }
 
 func TestNodeGet(t *testing.T) {
-	tests := []struct {
-		n    Node
-		keys []any
-		has  bool
-		want Node
+	testCases := []struct {
+		caseName string
+		n        Node
+		keys     []any
+		has      bool
+		want     Node
 	}{
 		{
-			n:    Array{StringValue("a"), StringValue("b")},
-			keys: []any{1},
-			has:  true,
-			want: StringValue("b"),
+			caseName: "Array int key",
+			n:        Array{StringValue("a"), StringValue("b")},
+			keys:     []any{1},
+			has:      true,
+			want:     StringValue("b"),
 		}, {
-			n:    Array{StringValue("a"), StringValue("b")},
-			keys: []any{"1"},
-			has:  true,
-			want: StringValue("b"),
+			caseName: "Array string-as-int key",
+			n:        Array{StringValue("a"), StringValue("b")},
+			keys:     []any{"1"},
+			has:      true,
+			want:     StringValue("b"),
 		}, {
-			n:    Array{StringValue("a"), StringValue("b")},
-			keys: []any{1.0},
-			want: Nil,
+			caseName: "Array float key invalid",
+			n:        Array{StringValue("a"), StringValue("b")},
+			keys:     []any{1.0},
+			want:     Nil,
 		}, {
-			n:    Array{StringValue("a"), StringValue("b")},
-			keys: []any{2},
-			want: Nil,
+			caseName: "Array out of range",
+			n:        Array{StringValue("a"), StringValue("b")},
+			keys:     []any{2},
+			want:     Nil,
 		}, {
-			n:    Array{StringValue("a"), nil},
-			keys: []any{1},
-			has:  true,
-			want: Nil,
+			caseName: "Array nil element",
+			n:        Array{StringValue("a"), nil},
+			keys:     []any{1},
+			has:      true,
+			want:     Nil,
 		}, {
-			n:    Map{"1": NumberValue(10), "2": NumberValue(20)},
-			keys: []any{"1"},
-			has:  true,
-			want: NumberValue(10),
+			caseName: "Map string key",
+			n:        Map{"1": NumberValue(10), "2": NumberValue(20)},
+			keys:     []any{"1"},
+			has:      true,
+			want:     NumberValue(10),
 		}, {
-			n:    Map{"1": NumberValue(10), "2": NumberValue(20)},
-			keys: []any{1},
-			has:  true,
-			want: NumberValue(10),
+			caseName: "Map int key",
+			n:        Map{"1": NumberValue(10), "2": NumberValue(20)},
+			keys:     []any{1},
+			has:      true,
+			want:     NumberValue(10),
 		}, {
-			n:    Map{"1": NumberValue(10), "2": NumberValue(20)},
-			keys: []any{1.0},
-			want: Nil,
+			caseName: "Map float key invalid",
+			n:        Map{"1": NumberValue(10), "2": NumberValue(20)},
+			keys:     []any{1.0},
+			want:     Nil,
 		}, {
-			n:    Map{"1": NumberValue(10), "2": NumberValue(20)},
-			keys: []any{"3"},
-			want: Nil,
+			caseName: "Map missing key",
+			n:        Map{"1": NumberValue(10), "2": NumberValue(20)},
+			keys:     []any{"3"},
+			want:     Nil,
 		}, {
-			n:    Map{"1": NumberValue(10), "2": nil},
-			keys: []any{"2"},
-			has:  true,
-			want: Nil,
+			caseName: "Map nil value",
+			n:        Map{"1": NumberValue(10), "2": nil},
+			keys:     []any{"2"},
+			has:      true,
+			want:     Nil,
 		}, {
-			n:    Map{"a": Map{"b": StringValue("v")}},
-			keys: []any{"a", "b"},
-			has:  true,
-			want: StringValue("v"),
+			caseName: "Map nested two keys",
+			n:        Map{"a": Map{"b": StringValue("v")}},
+			keys:     []any{"a", "b"},
+			has:      true,
+			want:     StringValue("v"),
 		}, {
-			n:    Map{"a": Map{"b": StringValue("v")}},
-			keys: []any{"a", "b", "c", "d"},
-			want: Nil,
+			caseName: "Map nested over-deep",
+			n:        Map{"a": Map{"b": StringValue("v")}},
+			keys:     []any{"a", "b", "c", "d"},
+			want:     Nil,
 		}, {
-			n:    Map{"a": Map{"b": StringValue("v")}},
-			keys: []any{"a", "c"},
-			want: Nil,
+			caseName: "Map nested missing leaf",
+			n:        Map{"a": Map{"b": StringValue("v")}},
+			keys:     []any{"a", "c"},
+			want:     Nil,
 		}, {
-			n:    Array{Array{nil, StringValue("v")}},
-			keys: []any{0, 1},
-			has:  true,
-			want: StringValue("v"),
+			caseName: "Array nested two indices",
+			n:        Array{Array{nil, StringValue("v")}},
+			keys:     []any{0, 1},
+			has:      true,
+			want:     StringValue("v"),
 		}, {
-			n:    Array{Array{nil, StringValue("v")}},
-			keys: []any{0, 1, 2, 3},
-			want: Nil,
+			caseName: "Array nested over-deep",
+			n:        Array{Array{nil, StringValue("v")}},
+			keys:     []any{0, 1, 2, 3},
+			want:     Nil,
 		}, {
-			n:    Array{Map{"a": Array{nil, Map{"b": StringValue("v")}}}},
-			keys: []any{0, "a", 1, "b"},
-			has:  true,
-			want: StringValue("v"),
+			caseName: "mixed Array Map Array Map deep",
+			n:        Array{Map{"a": Array{nil, Map{"b": StringValue("v")}}}},
+			keys:     []any{0, "a", 1, "b"},
+			has:      true,
+			want:     StringValue("v"),
 		}, {
-			n:    StringValue("str"),
-			want: Nil,
+			caseName: "StringValue no keys",
+			n:        StringValue("str"),
+			want:     Nil,
 		}, {
-			n:    BoolValue(true),
-			want: Nil,
+			caseName: "BoolValue no keys",
+			n:        BoolValue(true),
+			want:     Nil,
 		}, {
-			n:    NumberValue(1),
-			want: Nil,
+			caseName: "NumberValue no keys",
+			n:        NumberValue(1),
+			want:     Nil,
 		},
 	}
-	for i, test := range tests {
-		if test.n.Has(test.keys...) != test.has {
-			t.Errorf("tests[%d] Has got %v; want %v", i, !test.has, test.has)
-		}
-		got := test.n.Get(test.keys...)
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] Get got %v; want %v", i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if tc.n.Has(tc.keys...) != tc.has {
+				t.Errorf("Has got %v; want %v", !tc.has, tc.has)
+			}
+			got := tc.n.Get(tc.keys...)
+			if !Equal(got, tc.want) {
+				t.Errorf("Get got %v; want %v", got, tc.want)
+			}
+		})
 	}
 }
 
 func TestNodeEach(t *testing.T) {
-	tests := []struct {
-		n    Node
-		want map[any]Node
+	testCases := []struct {
+		caseName string
+		n        Node
+		want     map[any]Node
 	}{
 		{
-			n:    Array{StringValue("a"), StringValue("b")},
-			want: map[any]Node{0: StringValue("a"), 1: StringValue("b")},
+			caseName: "Array",
+			n:        Array{StringValue("a"), StringValue("b")},
+			want:     map[any]Node{0: StringValue("a"), 1: StringValue("b")},
 		}, {
-			n:    Map{"a": NumberValue(0), "b": NumberValue(1)},
-			want: map[any]Node{"a": NumberValue(0), "b": NumberValue(1)},
+			caseName: "Map",
+			n:        Map{"a": NumberValue(0), "b": NumberValue(1)},
+			want:     map[any]Node{"a": NumberValue(0), "b": NumberValue(1)},
 		}, {
-			n:    StringValue("str"),
-			want: map[any]Node{nil: StringValue("str")},
+			caseName: "StringValue",
+			n:        StringValue("str"),
+			want:     map[any]Node{nil: StringValue("str")},
 		}, {
-			n:    BoolValue(true),
-			want: map[any]Node{nil: BoolValue(true)},
+			caseName: "BoolValue",
+			n:        BoolValue(true),
+			want:     map[any]Node{nil: BoolValue(true)},
 		}, {
-			n:    NumberValue(1),
-			want: map[any]Node{nil: NumberValue(1)},
+			caseName: "NumberValue",
+			n:        NumberValue(1),
+			want:     map[any]Node{nil: NumberValue(1)},
 		}, {
-			n:    Any{Map{"a": NumberValue(0), "b": NumberValue(1)}},
-			want: map[any]Node{"a": NumberValue(0), "b": NumberValue(1)},
+			caseName: "Any wrapping Map",
+			n:        Any{Map{"a": NumberValue(0), "b": NumberValue(1)}},
+			want:     map[any]Node{"a": NumberValue(0), "b": NumberValue(1)},
 		},
 	}
-	for i, test := range tests {
-		got := map[any]Node{}
-		err := test.n.Each(func(key any, v Node) error {
-			got[key] = v
-			return nil
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got := map[any]Node{}
+			err := tc.n.Each(func(key any, v Node) error {
+				got[key] = v
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v; want %v", got, tc.want)
+			}
+			wantErr := fmt.Errorf("err for %s", tc.caseName)
+			gotErr := tc.n.Each(func(key any, v Node) error {
+				return wantErr
+			})
+			if wantErr != gotErr {
+				t.Errorf("got %v; want %v", gotErr, wantErr)
+			}
 		})
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] got %v; want %v", i, got, test.want)
-		}
-		wantErr := fmt.Errorf("test%d", i)
-		gotErr := test.n.Each(func(key any, v Node) error {
-			return wantErr
-		})
-		if wantErr != gotErr {
-			t.Errorf("tests[%d] got %v; want %v", i, gotErr, wantErr)
-		}
 	}
 }
 
 func TestNodeFind(t *testing.T) {
-	tests := []struct {
-		n    Node
-		expr string
-		want []Node
+	testCases := []struct {
+		caseName string
+		n        Node
+		expr     string
+		want     []Node
 	}{
 		{
-			n:    Array{StringValue("a"), StringValue("b")},
-			expr: ".[0]",
-			want: []Node{StringValue("a")},
+			caseName: "Array index",
+			n:        Array{StringValue("a"), StringValue("b")},
+			expr:     ".[0]",
+			want:     []Node{StringValue("a")},
 		}, {
-			n:    Map{"1": NumberValue(10), "2": NumberValue(20)},
-			expr: ".1",
-			want: []Node{NumberValue(10)},
+			caseName: "Map key",
+			n:        Map{"1": NumberValue(10), "2": NumberValue(20)},
+			expr:     ".1",
+			want:     []Node{NumberValue(10)},
 		},
 	}
-	for i, test := range tests {
-		got, err := test.n.Find(test.expr)
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] got %#v; want %#v", i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got, err := tc.n.Find(tc.expr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !Equal(Array(got), Array(tc.want)) {
+				t.Errorf("got %#v; want %#v", got, tc.want)
+			}
+		})
 	}
 }
 
 func TestEditorNodeAppend(t *testing.T) {
-	tests := []struct {
-		n      EditorNode
-		values []Node
-		want   EditorNode
-		errstr string
+	testCases := []struct {
+		caseName string
+		n        EditorNode
+		values   []Node
+		want     EditorNode
+		errstr   string
 	}{
 		{
-			n:      &Array{NumberValue(1)},
-			values: []Node{StringValue("2"), BoolValue(true)},
-			want:   &Array{NumberValue(1), StringValue("2"), BoolValue(true)},
+			caseName: "Array",
+			n:        &Array{NumberValue(1)},
+			values:   []Node{StringValue("2"), BoolValue(true)},
+			want:     &Array{NumberValue(1), StringValue("2"), BoolValue(true)},
 		}, {
-			n:      Map{},
-			values: []Node{StringValue("2")},
-			errstr: "cannot append to map",
+			caseName: "Map rejected",
+			n:        Map{},
+			values:   []Node{StringValue("2")},
+			errstr:   "cannot append to map",
 		},
 	}
-	for i, test := range tests {
-		var err error
-		for _, value := range test.values {
-			err = test.n.Append(value)
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			var err error
+			for _, value := range tc.values {
+				err = tc.n.Append(value)
+				if err != nil {
+					break
+				}
+			}
+			if tc.errstr != "" {
+				if err == nil {
+					t.Fatal("no error")
+				}
+				if err.Error() != tc.errstr {
+					t.Errorf("got %s; want %s", err.Error(), tc.errstr)
+				}
+				return
+			}
 			if err != nil {
-				break
+				t.Fatal(err)
 			}
-		}
-		if test.errstr != "" {
-			if err == nil {
-				t.Fatalf("tests[%d] no error", i)
+			got := tc.n
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v; want %v", got, tc.want)
 			}
-			if err.Error() != test.errstr {
-				t.Errorf("tests[%d] got %s; want %s", i, err.Error(), test.errstr)
-			}
-			continue
-		}
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		got := test.n
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] got %v; want %v", i, got, test.want)
-		}
+		})
 	}
 }
 
 func TestEditorNodeSet(t *testing.T) {
-	tests := []struct {
-		n       EditorNode
-		entries map[any]Node
-		want    EditorNode
-		errstr  string
+	testCases := []struct {
+		caseName string
+		n        EditorNode
+		entries  map[any]Node
+		want     EditorNode
+		errstr   string
 	}{
 		{
-			n: &Array{NumberValue(0), StringValue("1")},
+			caseName: "Array set existing and append",
+			n:        &Array{NumberValue(0), StringValue("1")},
 			entries: map[any]Node{
 				0:   NumberValue(1),
 				"1": StringValue("2"),
@@ -440,10 +497,12 @@ func TestEditorNodeSet(t *testing.T) {
 			},
 			want: &Array{NumberValue(1), StringValue("2"), BoolValue(true)},
 		}, {
-			n:       &Array{},
-			entries: map[any]Node{-2: StringValue("value")},
-			errstr:  "cannot index array with -2",
+			caseName: "Array negative index rejected",
+			n:        &Array{},
+			entries:  map[any]Node{-2: StringValue("value")},
+			errstr:   "cannot index array with -2",
 		}, {
+			caseName: "Map set and add new keys",
 			n: Map{
 				"1": NumberValue(1),
 				"2": StringValue("2"),
@@ -462,54 +521,61 @@ func TestEditorNodeSet(t *testing.T) {
 				"5": BoolValue(true),
 			},
 		}, {
-			n:       Map{},
-			entries: map[any]Node{true: StringValue("value")},
-			errstr:  "cannot index array with true",
+			caseName: "Map bool key rejected",
+			n:        Map{},
+			entries:  map[any]Node{true: StringValue("value")},
+			errstr:   "cannot index array with true",
 		},
 	}
-	for i, test := range tests {
-		var err error
-		for key, value := range test.entries {
-			err = test.n.Set(key, value)
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			var err error
+			for key, value := range tc.entries {
+				err = tc.n.Set(key, value)
+				if err != nil {
+					break
+				}
+			}
+			if tc.errstr != "" {
+				if err == nil {
+					t.Fatal("no error")
+				}
+				if err.Error() != tc.errstr {
+					t.Errorf("got %s; want %s", err.Error(), tc.errstr)
+				}
+				return
+			}
 			if err != nil {
-				break
+				t.Fatal(err)
 			}
-		}
-		if test.errstr != "" {
-			if err == nil {
-				t.Fatalf("tests[%d] no error", i)
+			got := tc.n
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v; want %v", got, tc.want)
 			}
-			if err.Error() != test.errstr {
-				t.Errorf(`tests[%d] got %s; want %s`, i, err.Error(), test.errstr)
-			}
-			continue
-		}
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		got := test.n
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] got %v; want %v", i, got, test.want)
-		}
+		})
 	}
 }
 
 func TestEditorNodeDelete(t *testing.T) {
-	tests := []struct {
-		n      EditorNode
-		keys   []any
-		want   EditorNode
-		errstr string
+	testCases := []struct {
+		caseName string
+		n        EditorNode
+		keys     []any
+		want     EditorNode
+		errstr   string
 	}{
 		{
-			n:    &Array{NumberValue(1), StringValue("1"), BoolValue(true)},
-			keys: []any{1, "1"},
-			want: &Array{NumberValue(1)},
+			caseName: "Array delete by int and string-as-int",
+			n:        &Array{NumberValue(1), StringValue("1"), BoolValue(true)},
+			keys:     []any{1, "1"},
+			want:     &Array{NumberValue(1)},
 		}, {
-			n:      &Array{},
-			keys:   []any{-1},
-			errstr: "cannot index array with -1",
+			caseName: "Array negative index rejected",
+			n:        &Array{},
+			keys:     []any{-1},
+			errstr:   "cannot index array with -1",
 		}, {
+			caseName: "Map delete mixed keys",
 			n: Map{
 				"1": NumberValue(1),
 				"2": StringValue("2"),
@@ -523,35 +589,38 @@ func TestEditorNodeDelete(t *testing.T) {
 				"3": BoolValue(true),
 			},
 		}, {
-			n:      Map{},
-			keys:   []any{true},
-			errstr: "cannot index array with true",
+			caseName: "Map bool key rejected",
+			n:        Map{},
+			keys:     []any{true},
+			errstr:   "cannot index array with true",
 		},
 	}
-	for i, test := range tests {
-		var err error
-		for _, key := range test.keys {
-			err = test.n.Delete(key)
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			var err error
+			for _, key := range tc.keys {
+				err = tc.n.Delete(key)
+				if err != nil {
+					break
+				}
+			}
+			if tc.errstr != "" {
+				if err == nil {
+					t.Fatal("no error")
+				}
+				if err.Error() != tc.errstr {
+					t.Errorf("got %s; want %s", err.Error(), tc.errstr)
+				}
+				return
+			}
 			if err != nil {
-				break
+				t.Fatal(err)
 			}
-		}
-		if test.errstr != "" {
-			if err == nil {
-				t.Fatalf("tests[%d] no error", i)
+			got := tc.n
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v; want %v", got, tc.want)
 			}
-			if err.Error() != test.errstr {
-				t.Errorf("tests[%d] got %s; want %s", i, err.Error(), test.errstr)
-			}
-			continue
-		}
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		got := test.n
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] got %v; want %v", i, got, test.want)
-		}
+		})
 	}
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func Test_Type(t *testing.T) {
+func TestType(t *testing.T) {
 	tests := []struct {
 		typ  Type
 		is   func() bool
@@ -62,7 +62,7 @@ func Test_Type(t *testing.T) {
 	}
 }
 
-func Test_Type_String(t *testing.T) {
+func TestTypeString(t *testing.T) {
 	testCases := []struct {
 		caseName string
 		typ      Type
@@ -87,7 +87,7 @@ func Test_Type_String(t *testing.T) {
 	}
 }
 
-func Test_Node(t *testing.T) {
+func TestNode(t *testing.T) {
 	tests := []struct {
 		n         Node
 		isNil     bool
@@ -204,7 +204,7 @@ func Test_Node(t *testing.T) {
 	}
 }
 
-func Test_Node_Get(t *testing.T) {
+func TestNodeGet(t *testing.T) {
 	tests := []struct {
 		n    Node
 		keys []any
@@ -306,7 +306,7 @@ func Test_Node_Get(t *testing.T) {
 	}
 }
 
-func Test_Node_Each(t *testing.T) {
+func TestNodeEach(t *testing.T) {
 	tests := []struct {
 		n    Node
 		want map[any]Node
@@ -353,7 +353,7 @@ func Test_Node_Each(t *testing.T) {
 	}
 }
 
-func Test_Node_Find(t *testing.T) {
+func TestNodeFind(t *testing.T) {
 	tests := []struct {
 		n    Node
 		expr string
@@ -380,7 +380,7 @@ func Test_Node_Find(t *testing.T) {
 	}
 }
 
-func Test_EditorNode_Append(t *testing.T) {
+func TestEditorNodeAppend(t *testing.T) {
 	tests := []struct {
 		n      EditorNode
 		values []Node
@@ -424,7 +424,7 @@ func Test_EditorNode_Append(t *testing.T) {
 	}
 }
 
-func Test_EditorNode_Set(t *testing.T) {
+func TestEditorNodeSet(t *testing.T) {
 	tests := []struct {
 		n       EditorNode
 		entries map[any]Node
@@ -494,7 +494,7 @@ func Test_EditorNode_Set(t *testing.T) {
 	}
 }
 
-func Test_EditorNode_Delete(t *testing.T) {
+func TestEditorNodeDelete(t *testing.T) {
 	tests := []struct {
 		n      EditorNode
 		keys   []any

--- a/util_test.go
+++ b/util_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func Test_V(t *testing.T) {
+func TestV(t *testing.T) {
 	// V is a thin alias for ToValue; sample a few representative
 	// inputs to confirm they yield identical results.
 	inputs := []any{nil, "s", true, 1, int64(2), 3.5}
@@ -16,7 +16,7 @@ func Test_V(t *testing.T) {
 	}
 }
 
-func Test_A(t *testing.T) {
+func TestA(t *testing.T) {
 	// A is a thin alias for ToArrayValues.
 	got := A("a", 1, true)
 	want := ToArrayValues("a", 1, true)
@@ -25,7 +25,7 @@ func Test_A(t *testing.T) {
 	}
 }
 
-func Test_ToValue(t *testing.T) {
+func TestToValue(t *testing.T) {
 	tests := []struct {
 		v    any
 		want Node
@@ -76,7 +76,7 @@ func Test_ToValue(t *testing.T) {
 	}
 }
 
-func Test_ToNode(t *testing.T) {
+func TestToNode(t *testing.T) {
 	tests := []struct {
 		v    any
 		want Node
@@ -103,7 +103,7 @@ func Test_ToNode(t *testing.T) {
 	}
 }
 
-func Test_Walk(t *testing.T) {
+func TestWalk(t *testing.T) {
 	root := Array{
 		Map{"ID": ToValue(1)},
 		Map{"ID": ToValue(2), "Sub": Array{Map{"ID": ToValue(20)}}},
@@ -174,7 +174,7 @@ func Test_Walk(t *testing.T) {
 	}
 }
 
-func Test_regexpMatchString(t *testing.T) {
+func TestRegexpMatchString(t *testing.T) {
 	tests := []struct {
 		expr   string
 		value  string

--- a/util_test.go
+++ b/util_test.go
@@ -8,11 +8,23 @@ import (
 func TestV(t *testing.T) {
 	// V is a thin alias for ToValue; sample a few representative
 	// inputs to confirm they yield identical results.
-	inputs := []any{nil, "s", true, 1, int64(2), 3.5}
-	for _, in := range inputs {
-		if got, want := V(in), ToValue(in); got != want {
-			t.Errorf("V(%v) = %#v; want %#v", in, got, want)
-		}
+	testCases := []struct {
+		caseName string
+		in       any
+	}{
+		{caseName: "nil", in: nil},
+		{caseName: "string", in: "s"},
+		{caseName: "bool", in: true},
+		{caseName: "int", in: 1},
+		{caseName: "int64", in: int64(2)},
+		{caseName: "float64", in: 3.5},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got, want := V(tc.in), ToValue(tc.in); got != want {
+				t.Errorf("V(%v) = %#v; want %#v", tc.in, got, want)
+			}
+		})
 	}
 }
 
@@ -20,86 +32,64 @@ func TestA(t *testing.T) {
 	// A is a thin alias for ToArrayValues.
 	got := A("a", 1, true)
 	want := ToArrayValues("a", 1, true)
-	if !reflect.DeepEqual(got, want) {
+	if !Equal(got, want) {
 		t.Errorf("A(...) = %#v; want %#v", got, want)
 	}
 }
 
 func TestToValue(t *testing.T) {
-	tests := []struct {
-		v    any
-		want Node
+	testCases := []struct {
+		caseName string
+		v        any
+		want     Node
 	}{
-		{
-			v:    nil,
-			want: Nil,
-		}, {
-			v:    "string",
-			want: StringValue("string"),
-		}, {
-			v:    true,
-			want: BoolValue(true),
-		}, {
-			v:    1,
-			want: NumberValue(1),
-		}, {
-			v:    int64(2),
-			want: NumberValue(2),
-		}, {
-			v:    int32(3),
-			want: NumberValue(3),
-		}, {
-			v:    float64(4.4),
-			want: NumberValue(4.4),
-		}, {
-			v:    float32(5.5),
-			want: NumberValue(5.5),
-		}, {
-			v:    uint64(6),
-			want: NumberValue(uint64(6)),
-		}, {
-			v:    uint32(7),
-			want: NumberValue(uint32(7)),
-		}, {
-			v:    BoolValue(true),
-			want: BoolValue(true),
-		}, {
-			v:    struct{}{},
-			want: StringValue("struct {}{}"),
-		},
+		{caseName: "nil", v: nil, want: Nil},
+		{caseName: "string", v: "string", want: StringValue("string")},
+		{caseName: "bool", v: true, want: BoolValue(true)},
+		{caseName: "int", v: 1, want: NumberValue(1)},
+		{caseName: "int64", v: int64(2), want: NumberValue(2)},
+		{caseName: "int32", v: int32(3), want: NumberValue(3)},
+		{caseName: "float64", v: float64(4.4), want: NumberValue(4.4)},
+		{caseName: "float32", v: float32(5.5), want: NumberValue(5.5)},
+		{caseName: "uint64", v: uint64(6), want: NumberValue(uint64(6))},
+		{caseName: "uint32", v: uint32(7), want: NumberValue(uint32(7))},
+		{caseName: "BoolValue passthrough", v: BoolValue(true), want: BoolValue(true)},
+		{caseName: "unknown struct fallback", v: struct{}{}, want: StringValue("struct {}{}")},
 	}
-	for i, test := range tests {
-		got := ToValue(test.v)
-		if got != test.want {
-			t.Errorf("tests[%d] for %v; got %#v; want %#v", i, test.v, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got := ToValue(tc.v); !Equal(got, tc.want) {
+				t.Errorf("for %v; got %#v; want %#v", tc.v, got, tc.want)
+			}
+		})
 	}
 }
 
 func TestToNode(t *testing.T) {
-	tests := []struct {
-		v    any
-		want Node
+	testCases := []struct {
+		caseName string
+		v        any
+		want     Node
 	}{
+		{caseName: "nil", v: nil, want: Nil},
+		{caseName: "StringValue", v: StringValue("a"), want: StringValue("a")},
 		{
-			v:    nil,
-			want: Nil,
-		}, {
-			v:    StringValue("a"),
-			want: StringValue("a"),
-		}, {
-			v:    map[string]any{"a": 1, "b": true},
-			want: Map{"a": NumberValue(1), "b": BoolValue(true)},
-		}, {
-			v:    []any{"a", true, 1},
-			want: Array{StringValue("a"), BoolValue(true), NumberValue(1)},
+			caseName: "map",
+			v:        map[string]any{"a": 1, "b": true},
+			want:     Map{"a": NumberValue(1), "b": BoolValue(true)},
+		},
+		{
+			caseName: "slice",
+			v:        []any{"a", true, 1},
+			want:     Array{StringValue("a"), BoolValue(true), NumberValue(1)},
 		},
 	}
-	for i, test := range tests {
-		got := ToNode(test.v)
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] for %v; got %v; want %v", i, test.v, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got := ToNode(tc.v); !Equal(got, tc.want) {
+				t.Errorf("for %v; got %v; want %v", tc.v, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -110,7 +100,7 @@ func TestWalk(t *testing.T) {
 		Map{"ID": ToValue(3), "Sub": Array{Map{"ID": ToValue(30)}}},
 	}
 
-	tests := []struct {
+	expected := []struct {
 		n    Node
 		keys []any
 		skip bool
@@ -148,20 +138,20 @@ func TestWalk(t *testing.T) {
 
 	i := 0
 	err := Walk(root, func(n Node, keys []any) error {
-		if i >= len(tests) {
+		if i >= len(expected) {
 			t.Fatalf("fn is called too many times %d", i)
 			return nil
 		}
-		test := tests[i]
+		want := expected[i]
 		i++
 
-		if !reflect.DeepEqual(n, test.n) {
-			t.Errorf("walk[%d] got %#v; want %#v", i, n, test.n)
+		if !Equal(n, want.n) {
+			t.Errorf("walk[%d] got %#v; want %#v", i, n, want.n)
 		}
-		if !reflect.DeepEqual(keys, test.keys) {
-			t.Errorf("walk[%d] got %#v; want %#v", i, keys, test.n)
+		if !reflect.DeepEqual(keys, want.keys) {
+			t.Errorf("walk[%d] got %#v; want %#v", i, keys, want.keys)
 		}
-		if test.skip {
+		if want.skip {
 			return SkipWalk
 		}
 		return nil
@@ -169,103 +159,116 @@ func TestWalk(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(tests) != i {
-		t.Errorf("fn is called %d times; want %d", i, len(tests))
+	if len(expected) != i {
+		t.Errorf("fn is called %d times; want %d", i, len(expected))
 	}
 }
 
 func TestRegexpMatchString(t *testing.T) {
-	tests := []struct {
-		expr   string
-		value  string
-		want   bool
-		errstr string
+	testCases := []struct {
+		caseName string
+		expr     string
+		value    string
+		want     bool
+		errstr   string
 	}{
 		{
-			expr:  `a`,
-			value: "abc",
-			want:  true,
+			caseName: "substring match",
+			expr:     `a`,
+			value:    "abc",
+			want:     true,
 		}, {
-			expr:  `^[a-z]+$`,
-			value: "abc",
-			want:  true,
+			caseName: "anchored full match",
+			expr:     `^[a-z]+$`,
+			value:    "abc",
+			want:     true,
 		}, {
-			expr:  `x`,
-			value: "abc",
-			want:  false,
+			caseName: "no match",
+			expr:     `x`,
+			value:    "abc",
+			want:     false,
 		}, {
-			expr:   `(`,
-			value:  "abc",
-			errstr: "error parsing regexp: missing closing ): `(`",
+			caseName: "invalid regex",
+			expr:     `(`,
+			value:    "abc",
+			errstr:   "error parsing regexp: missing closing ): `(`",
 		},
 	}
-	for i, test := range tests {
-		got, err := regexpMatchString(test.expr, test.value)
-		if test.errstr != "" {
-			if err == nil {
-				t.Fatalf("tests[%d] for %v; no error", i, test.expr)
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got, err := regexpMatchString(tc.expr, tc.value)
+			if tc.errstr != "" {
+				if err == nil {
+					t.Fatalf("for %v; no error", tc.expr)
+				}
+				if err.Error() != tc.errstr {
+					t.Errorf("for %v; got %v want %v", tc.expr, err.Error(), tc.errstr)
+				}
+				return
 			}
-			if err.Error() != test.errstr {
-				t.Errorf(`tests[%d] for %v; got %v want %v`, i, test.expr, err.Error(), test.errstr)
+			if err != nil {
+				t.Fatalf("for %v; %+v", tc.expr, err)
 			}
-			continue
-		}
-		if err != nil {
-			t.Fatalf("tests[%d] for %v; %+v", i, test.expr, err)
-		}
-		if got != test.want {
-			t.Errorf("tests[%d] for %v; got %v; want %v", i, test.expr, got, test.want)
-		}
+			if got != tc.want {
+				t.Errorf("for %v; got %v; want %v", tc.expr, got, tc.want)
+			}
+		})
 	}
 }
 
 func TestClone(t *testing.T) {
-	tests := []struct {
-		n    Node
-		want Node
+	testCases := []struct {
+		caseName string
+		n        Node
+		want     Node
 	}{
+		{caseName: "Value", n: ToValue(1), want: ToValue(1)},
 		{
-			n:    ToValue(1),
-			want: ToValue(1),
-		}, {
-			n:    Map{"a": ToValue(1), "b": ToValue(2)},
-			want: Map{"a": ToValue(1), "b": ToValue(2)},
+			caseName: "Map",
+			n:        Map{"a": ToValue(1), "b": ToValue(2)},
+			want:     Map{"a": ToValue(1), "b": ToValue(2)},
 		},
 	}
-	for i, test := range tests {
-		got := Clone(test.n)
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf(`tests[%d]: unexpected %v; want %v`, i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got := Clone(tc.n); !Equal(got, tc.want) {
+				t.Errorf("unexpected %v; want %v", got, tc.want)
+			}
+		})
 	}
 }
 
 func TestCloneDeep(t *testing.T) {
-	tests := []struct {
-		n      Node
-		want   Node
-		update func(n Node)
+	testCases := []struct {
+		caseName string
+		n        Node
+		want     Node
+		update   func(n Node)
 	}{
 		{
-			n:      ToValue(1),
-			want:   ToValue(1),
-			update: func(n Node) {},
+			caseName: "Value",
+			n:        ToValue(1),
+			want:     ToValue(1),
+			update:   func(n Node) {},
 		}, {
-			n:    Map{"a": ToArrayValues(1, 2), "b": ToArrayValues(3, 4)},
-			want: Map{"a": ToArrayValues(1, 2), "b": ToArrayValues(3, 4)},
+			caseName: "Map of Arrays mutated post-clone",
+			n:        Map{"a": ToArrayValues(1, 2), "b": ToArrayValues(3, 4)},
+			want:     Map{"a": ToArrayValues(1, 2), "b": ToArrayValues(3, 4)},
 			update: func(n Node) {
 				n.Map().Get("a").Array()[0] = ToValue(5)
 			},
 		},
 	}
-	for i, test := range tests {
-		got := CloneDeep(test.n)
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf(`tests[%d]: unexpected %v; want %v`, i, got, test.want)
-		}
-		test.update(test.n)
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf(`tests[%d]: unexpected %v; want %v`, i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got := CloneDeep(tc.n)
+			if !Equal(got, tc.want) {
+				t.Errorf("unexpected %v; want %v", got, tc.want)
+			}
+			tc.update(tc.n)
+			if !Equal(got, tc.want) {
+				t.Errorf("after update unexpected %v; want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/value_test.go
+++ b/value_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func Test_Value(t *testing.T) {
+func TestValue(t *testing.T) {
 	tests := []struct {
 		value Node
 		b     bool
@@ -70,7 +70,7 @@ func Test_Value(t *testing.T) {
 	}
 }
 
-func Test_Value_Compare(t *testing.T) {
+func TestValueCompare(t *testing.T) {
 	tests := []struct {
 		n    Value
 		op   Operator
@@ -143,7 +143,7 @@ func Test_Value_Compare(t *testing.T) {
 	}
 }
 
-func Test_Value_Find(t *testing.T) {
+func TestValueFind(t *testing.T) {
 	tests := []struct {
 		n    Node
 		expr string

--- a/value_test.go
+++ b/value_test.go
@@ -1,77 +1,71 @@
 package tree
 
 import (
-	"reflect"
+	"fmt"
 	"testing"
 )
 
 func TestValue(t *testing.T) {
-	tests := []struct {
-		value Node
-		b     bool
-		i     int
-		i64   int64
-		f64   float64
-		s     string
+	testCases := []struct {
+		caseName string
+		value    Node
+		want     Node
 	}{
-		{
-			value: Nil,
-		}, {
-			value: StringValue("test"),
-			s:     "test",
-		}, {
-			value: BoolValue(true),
-			b:     true,
-			s:     "true",
-		}, {
-			value: NumberValue(1),
-			i:     1,
-			i64:   int64(1),
-			f64:   float64(1),
-			s:     "1",
-		}, {
-			value: NumberValue(2.3),
-			i:     2,
-			i64:   int64(2),
-			f64:   float64(2.3),
-			s:     "2.3",
-		},
+		{caseName: "Nil", value: Nil, want: Nil},
+		{caseName: "StringValue", value: StringValue("test"), want: StringValue("test")},
+		{caseName: "BoolValue", value: BoolValue(true), want: BoolValue(true)},
+		{caseName: "NumberValue int", value: NumberValue(1), want: NumberValue(1)},
+		{caseName: "NumberValue float", value: NumberValue(2.3), want: NumberValue(2.3)},
 	}
-	for i, test := range tests {
-		v := test.value
-		vv := v.Value()
-		if tt := v.Type(); tt&TypeValue == 0 {
-			t.Errorf("tests[%d] Type got %v; want TypeValue", i, tt)
-		}
-		if a := v.Array(); a != nil {
-			t.Errorf("tests[%d] Array got %v; want nil", i, a)
-		}
-		if m := v.Map(); m != nil {
-			t.Errorf("tests[%d] Map got %v; want nil", i, m)
-		}
-		if vv.(Node) != v {
-			t.Errorf("tests[%d] Value got %v; want %v", i, vv, v)
-		}
-		if b := vv.Bool(); b != test.b {
-			t.Errorf("tests[%d] Bool got %v; want %v", i, b, test.b)
-		}
-		if ii := vv.Int(); ii != test.i {
-			t.Errorf("tests[%d] Int got %v; want %v", i, ii, test.i)
-		}
-		if i64 := vv.Int64(); i64 != test.i64 {
-			t.Errorf("tests[%d] Int64 got %v; want %v", i, i64, test.i64)
-		}
-		if f64 := vv.Float64(); f64 != test.f64 {
-			t.Errorf("tests[%d] Float64 got %v; want %v", i, f64, test.f64)
-		}
-		if s := vv.String(); s != test.s {
-			t.Errorf("tests[%d] String got %v; want %v", i, s, test.s)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got := tc.value.Value()
+			if !Equal(got, tc.want) {
+				t.Errorf("Value got %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValueAs(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		value    Value
+		b        bool
+		i        int
+		i64      int64
+		f64      float64
+		s        string
+	}{
+		{caseName: "Nil", value: Nil},
+		{caseName: "StringValue", value: StringValue("test"), s: "test"},
+		{caseName: "BoolValue true", value: BoolValue(true), b: true, s: "true"},
+		{caseName: "NumberValue int", value: NumberValue(1), i: 1, i64: 1, f64: 1, s: "1"},
+		{caseName: "NumberValue float", value: NumberValue(2.3), i: 2, i64: 2, f64: 2.3, s: "2.3"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if got := tc.value.Bool(); got != tc.b {
+				t.Errorf("Bool got %v; want %v", got, tc.b)
+			}
+			if got := tc.value.Int(); got != tc.i {
+				t.Errorf("Int got %v; want %v", got, tc.i)
+			}
+			if got := tc.value.Int64(); got != tc.i64 {
+				t.Errorf("Int64 got %v; want %v", got, tc.i64)
+			}
+			if got := tc.value.Float64(); got != tc.f64 {
+				t.Errorf("Float64 got %v; want %v", got, tc.f64)
+			}
+			if got := tc.value.String(); got != tc.s {
+				t.Errorf("String got %v; want %v", got, tc.s)
+			}
+		})
 	}
 }
 
 func TestValueCompare(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		n    Value
 		op   Operator
 		v    Value
@@ -135,41 +129,49 @@ func TestValueCompare(t *testing.T) {
 		{BoolValue(true), NE, BoolValue(false), true},
 		{BoolValue(true), NE, StringValue("true"), true},
 	}
-	for i, test := range tests {
-		got := test.n.Compare(test.op, test.v)
-		if got != test.want {
-			t.Errorf("tests[%d] got %v; want %v", i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v %s %v", tc.n, tc.op, tc.v), func(t *testing.T) {
+			got := tc.n.Compare(tc.op, tc.v)
+			if got != tc.want {
+				t.Errorf("got %v; want %v", got, tc.want)
+			}
+		})
 	}
 }
 
 func TestValueFind(t *testing.T) {
-	tests := []struct {
-		n    Node
-		expr string
-		want []Node
+	testCases := []struct {
+		caseName string
+		n        Node
+		expr     string
+		want     []Node
 	}{
 		{
-			n:    StringValue("str"),
-			expr: ".",
-			want: []Node{StringValue("str")},
+			caseName: "StringValue",
+			n:        StringValue("str"),
+			expr:     ".",
+			want:     []Node{StringValue("str")},
 		}, {
-			n:    BoolValue(true),
-			expr: ".",
-			want: []Node{BoolValue(true)},
+			caseName: "BoolValue",
+			n:        BoolValue(true),
+			expr:     ".",
+			want:     []Node{BoolValue(true)},
 		}, {
-			n:    NumberValue(1),
-			expr: ".",
-			want: []Node{NumberValue(1)},
+			caseName: "NumberValue",
+			n:        NumberValue(1),
+			expr:     ".",
+			want:     []Node{NumberValue(1)},
 		},
 	}
-	for i, test := range tests {
-		got, err := test.n.Find(test.expr)
-		if err != nil {
-			t.Fatalf("tests[%d] %v", i, err)
-		}
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] got %#v; want %#v", i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got, err := tc.n.Find(tc.expr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !Equal(Array(got), Array(tc.want)) {
+				t.Errorf("got %#v; want %#v", got, tc.want)
+			}
+		})
 	}
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -9,106 +9,119 @@ import (
 )
 
 func TestMarshalYAML(t *testing.T) {
-	want := `a:
+	testCases := []struct {
+		caseName string
+		n        Node
+		want     string
+	}{
+		{
+			caseName: "Map with Array containing Nil values",
+			n: Map{
+				"a": Array{
+					StringValue("1"),
+					NumberValue(2),
+					BoolValue(true),
+					Nil,
+					nil,
+				},
+			},
+			want: `a:
   - "1"
   - 2
   - true
   - null
   - null
-`
-	n := Map{
-		"a": Array{
-			StringValue("1"),
-			NumberValue(2),
-			BoolValue(true),
-			Nil,
-			nil,
+`,
 		},
-	}
-	got, err := MarshalYAML(n)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != want {
-		t.Errorf("for %#v; got %s; want %s", n, string(got), want)
-	}
-}
-
-func TestMapMarshalYAML(t *testing.T) {
-	want := `a:
+		{
+			caseName: "Map with Array",
+			n: Map{
+				"a": Array{
+					StringValue("1"),
+					NumberValue(2),
+					BoolValue(true),
+				},
+			},
+			want: `a:
   - "1"
   - 2
   - true
-`
-	n := Map{
-		"a": Array{
-			StringValue("1"),
-			NumberValue(2),
-			BoolValue(true),
+`,
 		},
-	}
-	got, err := MarshalYAML(n)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != want {
-		t.Errorf("for %#v; got %s; want %s", n, string(got), want)
-	}
-}
-
-func TestArrayMarshalYAML(t *testing.T) {
-	want := `- "1"
+		{
+			caseName: "Array",
+			n: Array{
+				StringValue("1"),
+				NumberValue(2),
+				BoolValue(true),
+			},
+			want: `- "1"
 - 2
 - true
-`
-	n := Array{
-		StringValue("1"),
-		NumberValue(2),
-		BoolValue(true),
+`,
+		},
 	}
-	got, err := MarshalYAML(n)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != want {
-		t.Errorf("for %#v; marshaled %s; want %s", n, string(got), want)
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got, err := MarshalYAML(tc.n)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %s; want %s", string(got), tc.want)
+			}
+		})
 	}
 }
 
 func TestDecodeYAMLErrors(t *testing.T) {
-	tests := []struct {
-		data   []byte
-		errstr string
+	testCases := []struct {
+		caseName string
+		data     []byte
+		errstr   string
 	}{
 		{
-			data:   []byte(`"`),
-			errstr: "yaml: found unexpected end of stream",
+			caseName: "unexpected end of stream",
+			data:     []byte(`"`),
+			errstr:   "yaml: found unexpected end of stream",
 		}, {
-			data:   []byte(`}`),
-			errstr: "yaml: did not find expected node content",
+			caseName: "unexpected node content",
+			data:     []byte(`}`),
+			errstr:   "yaml: did not find expected node content",
 		}, {
-			data:   []byte("{\n1"),
-			errstr: `yaml: line 2: did not find expected ',' or '}'`,
+			caseName: "missing comma or brace",
+			data:     []byte("{\n1"),
+			errstr:   `yaml: line 2: did not find expected ',' or '}'`,
 		},
 	}
-	for i, test := range tests {
-		dec := yaml.NewDecoder(bytes.NewReader(test.data))
-		_, err := DecodeYAML(dec)
-		if err == nil {
-			t.Fatalf("tests[%d] no error", i)
-		}
-		if err.Error() != test.errstr {
-			t.Errorf("tests[%d] got %s; want %s", i, err.Error(), test.errstr)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			dec := yaml.NewDecoder(bytes.NewReader(tc.data))
+			_, err := DecodeYAML(dec)
+			if err == nil {
+				t.Fatal("no error")
+			}
+			if err.Error() != tc.errstr {
+				t.Errorf("got %s; want %s", err.Error(), tc.errstr)
+			}
+		})
 	}
 }
 
 func TestUnmarshalYAML(t *testing.T) {
-	tests := []struct {
-		want Node
-		data []byte
+	testCases := []struct {
+		caseName string
+		data     []byte
+		want     Node
 	}{
 		{
+			caseName: "Map with nested Array and Map",
+			data: []byte(`a: 1
+b: true
+c: null
+d: ["1",2,true]
+e: {"x":"x"}
+`),
 			want: Map{
 				"a": NumberValue(1),
 				"b": BoolValue(true),
@@ -122,13 +135,15 @@ func TestUnmarshalYAML(t *testing.T) {
 					"x": StringValue("x"),
 				},
 			},
-			data: []byte(`a: 1
-b: true
-c: null
-d: ["1",2,true]
-e: {"x":"x"}
-`),
 		}, {
+			caseName: "Array with nested Map and Array",
+			data: []byte(`- "1"
+- 2
+- true
+- null
+- {"a":1,"b":true,"c":null}
+- ["x"]
+`),
 			want: Array{
 				StringValue("1"),
 				NumberValue(2),
@@ -143,23 +158,18 @@ e: {"x":"x"}
 					StringValue("x"),
 				},
 			},
-			data: []byte(`- "1"
-- 2
-- true
-- null
-- {"a":1,"b":true,"c":null}
-- ["x"]
-`),
 		},
 	}
-	for i, test := range tests {
-		got, err := UnmarshalYAML(test.data)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] got %#v; want %#v", i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got, err := UnmarshalYAML(tc.data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !Equal(got, tc.want) {
+				t.Errorf("got %#v; want %#v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -177,7 +187,7 @@ c: null
 	if err := yaml.Unmarshal(data, &got); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !Equal(got, want) {
 		t.Errorf("got %#v; want %#v", got, want)
 	}
 }
@@ -196,17 +206,19 @@ func TestArrayUnmarshalYAML(t *testing.T) {
 	if err := yaml.Unmarshal(data, &got); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !Equal(got, want) {
 		t.Errorf("got %#v; want %#v", got, want)
 	}
 }
 
 func TestMarshalViaYAML(t *testing.T) {
-	tests := []struct {
-		v    any
-		want Node
+	testCases := []struct {
+		caseName string
+		v        any
+		want     Node
 	}{
 		{
+			caseName: "struct",
 			v: struct {
 				ID     int      `yaml:"id"`
 				Name   string   `yaml:"name"`
@@ -221,32 +233,23 @@ func TestMarshalViaYAML(t *testing.T) {
 				"name":   ToValue("Reds"),
 				"colors": ToArrayValues("Crimson", "Red", "Ruby", "Maroon"),
 			},
-		}, {
-			v:    "str",
-			want: StringValue("str"),
-		}, {
-			v:    true,
-			want: BoolValue(true),
-		}, {
-			v:    1,
-			want: NumberValue(1),
-		}, {
-			v:    nil,
-			want: Nil,
-		}, {
-			v:    BoolValue(true),
-			want: BoolValue(true),
 		},
+		{caseName: "string", v: "str", want: StringValue("str")},
+		{caseName: "bool", v: true, want: BoolValue(true)},
+		{caseName: "int", v: 1, want: NumberValue(1)},
+		{caseName: "nil", v: nil, want: Nil},
+		{caseName: "BoolValue passthrough", v: BoolValue(true), want: BoolValue(true)},
 	}
-
-	for i, test := range tests {
-		got, err := MarshalViaYAML(test.v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("tests[%d] got %#v; want %#v", i, got, test.want)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got, err := MarshalViaYAML(tc.v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !Equal(got, tc.want) {
+				t.Errorf("got %#v; want %#v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -8,7 +8,7 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-func Test_MarshalYAML(t *testing.T) {
+func TestMarshalYAML(t *testing.T) {
 	want := `a:
   - "1"
   - 2
@@ -34,7 +34,7 @@ func Test_MarshalYAML(t *testing.T) {
 	}
 }
 
-func Test_Map_MarshalYAML(t *testing.T) {
+func TestMapMarshalYAML(t *testing.T) {
 	want := `a:
   - "1"
   - 2
@@ -56,7 +56,7 @@ func Test_Map_MarshalYAML(t *testing.T) {
 	}
 }
 
-func Test_Array_MarshalYAML(t *testing.T) {
+func TestArrayMarshalYAML(t *testing.T) {
 	want := `- "1"
 - 2
 - true
@@ -75,7 +75,7 @@ func Test_Array_MarshalYAML(t *testing.T) {
 	}
 }
 
-func Test_DecodeYAML_Errors(t *testing.T) {
+func TestDecodeYAMLErrors(t *testing.T) {
 	tests := []struct {
 		data   []byte
 		errstr string
@@ -103,7 +103,7 @@ func Test_DecodeYAML_Errors(t *testing.T) {
 	}
 }
 
-func Test_UnmarshalYAML(t *testing.T) {
+func TestUnmarshalYAML(t *testing.T) {
 	tests := []struct {
 		want Node
 		data []byte
@@ -163,7 +163,7 @@ e: {"x":"x"}
 	}
 }
 
-func Test_Map_UnmarshalYAML(t *testing.T) {
+func TestMapUnmarshalYAML(t *testing.T) {
 	want := Map{
 		"a": NumberValue(1),
 		"b": BoolValue(true),
@@ -182,7 +182,7 @@ c: null
 	}
 }
 
-func Test_Array_UnmarshalYAML(t *testing.T) {
+func TestArrayUnmarshalYAML(t *testing.T) {
 	want := Array{
 		StringValue("1"),
 		NumberValue(2),
@@ -201,7 +201,7 @@ func Test_Array_UnmarshalYAML(t *testing.T) {
 	}
 }
 
-func Test_MarshalViaYAML(t *testing.T) {
+func TestMarshalViaYAML(t *testing.T) {
 	tests := []struct {
 		v    any
 		want Node
@@ -250,7 +250,7 @@ func Test_MarshalViaYAML(t *testing.T) {
 	}
 }
 
-func Test_UnmarshalViaYAML(t *testing.T) {
+func TestUnmarshalViaYAML(t *testing.T) {
 	m := Map{
 		"id":     ToValue(1),
 		"name":   ToValue("Reds"),


### PR DESCRIPTION
## Summary

- Sweeps every `_test.go` in the root package onto a single, predictable convention: `testCases` slice, `tc` loop variable, `caseName` field (or synthesized name where the case data already uniquely identifies it), and `t.Run(...)` subtests with per-case scoping.
- Renames the legacy `Test_Xxx` style to `TestXxx` (camelCase) so naming is uniform across files.
- Adopts `tree.Equal` (added in #83) for `Node` comparisons in tests, replacing `reflect.DeepEqual` where applicable. `reflect.DeepEqual` is retained where the comparison is not a `Node` (e.g. `[]any` keys in `TestWalk`, struct values in `TestUnmarshalViaJSON`/`TestUnmarshalViaYAML`, and `*Array`/`Map` mixed in `TestEditorNode*`).
- Folds redundant single-case tests where the function under test is identical: `TestMapMarshalYAML` / `TestArrayMarshalYAML` collapse into `TestMarshalYAML`; `TestMapMarshalJSON` / `TestArrayMarshalJSON` collapse into a new `TestNodeMarshalJSON` (kept separate from `TestMarshalJSON` because the latter exercises tree's own helper, not stdlib `json.Marshal`).
- Simplifies `t.Fatalf("%v", err)` and `t.Fatalf("no error")` to `t.Fatal(err)` / `t.Fatal("no error")`. Format-string `Fatalf` calls with real arguments (`%s`, `%q`, `%+v`, `tests[%d] %v`) are left alone.

## Per-file commits

- `test: Rename Test_Xxx to TestXxx for naming consistency` — 41 functions renamed, 7 files
- `test(value)` — `TestValue` split into `TestValue` (Equal-asserts `Value()` result) and a new `TestValueAs` (covers `Bool`/`Int`/`Int64`/`Float64`/`String`); `TestValueCompare`'s 57 cases use a synthesized `Sprintf` subtest name to keep the dense table compact
- `test(yaml)` — folds `TestMarshalYAML`/`TestMapMarshalYAML`/`TestArrayMarshalYAML` into one
- `test(json)` — folds `TestMapMarshalJSON`/`TestArrayMarshalJSON` into a new `TestNodeMarshalJSON`; `TestMarshalJSON` stays separate
- `test(node)` — `TestType` drops the unused `typ` field in favour of explicit `caseName`s; `TestNode`/`TestNodeGet`/`TestNodeFind` adopt `Equal`
- `test(util)` — `TestWalk` keeps its sequential structure (the slice is renamed to `expected` for clarity)
- `test(merge)` — 80 `MergeOption` cases get explicit `caseName`s; combined-options reuse a `overrideMapAppend` local
- `test(color)` — single-case `TestOutputColorJSON`/`TestOutputColorYAML` drop their unnecessary 1-iteration loop; `TestColorEncoderWriteQuotedJSONEscapes` (already conformant) is left untouched

## Test plan

- [x] `go test ./...` passes (every refactored subtest runs under `t.Run`, verified via `go test -v` spot-checks on each file)
- [x] `go vet ./...` clean
- [x] No commit on this branch contains `t.Fatalf("%v", err)` (verified by checking each commit's snapshot)
- [x] `tree.Equal` is the canonical `Node` comparison; `reflect.DeepEqual` is retained only where the compared value is not a `Node`