### PR TITLE
feat(schema): Add Map.KeyedRules and Any for closed object schemas

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -17,6 +17,7 @@ set of rules keyed by tree queries.
 
 - [What it does](#what-it-does)
 - [Getting started: flat rules](#getting-started-flat-rules)
+- [Closed object schemas with `Map.KeyedRules`](#closed-object-schemas-with-mapkeyedrules)
 - [Nested validation with `Every`](#nested-validation-with-every)
 - [`"[]"` suffix vs `Every`](#-suffix-vs-every)
 - [Filter queries and where they fall short](#filter-queries-and-where-they-fall-short)
@@ -85,6 +86,58 @@ err := schema.Validate(doc, schema.QueryRules{
 [`IntPtr`][IntPtr], [`Int64Ptr`][Int64Ptr], and
 [`Float64Ptr`][Float64Ptr] exist so you can set `Min`/`Max` inline
 without a temporary variable.
+
+## Closed object schemas with `Map.KeyedRules`
+
+The flat `QueryRules` style is convenient for sparse assertions over a
+larger document — pin a few paths, ignore the rest. When the goal is
+the opposite ("this map must look exactly like *this* shape"),
+[`Map.KeyedRules`][Map] lets one rule describe both the allow-list
+and the per-key validators:
+
+```go
+schema.Map{KeyedRules: map[string]schema.Rule{
+    "name": schema.Required(schema.String{}),
+    "age":  schema.Int{Min: schema.Int64Ptr(0), Max: schema.Int64Ptr(150)},
+    "tags": schema.Every{Rules: schema.QueryRules{
+        ".": schema.String{},
+    }},
+}}
+```
+
+- The keys of `KeyedRules` form the strict allow-list — any extra key
+  in the data surfaces as `unknown key "..."`.
+- Each entry's rule is invoked with the corresponding value, or
+  `tree.Nil` when the key is absent. Wrap with [`Required`][Required]
+  to make a field mandatory.
+- Nested `Map.KeyedRules` compose naturally; if the parent value is
+  absent, the leaf check is skipped (rather than reporting one error
+  per missing leaf).
+
+`Map.Keys` and `Map.KeyedRules` co-exist. `Keys` lists names accepted
+without any per-value rule (useful for grandfathered legacy fields);
+the strict allow-list becomes the union. To allow a specific key
+without imposing any check, drop an [`Any{}`][Any] entry into
+`KeyedRules`:
+
+```go
+schema.Map{KeyedRules: map[string]schema.Rule{
+    "name": schema.Required(schema.String{}),
+    "meta": schema.Any{}, // any value type is fine, but the key is recognised
+}}
+```
+
+**When to choose which:**
+
+| Scenario | Recommended |
+| -------- | ----------- |
+| "These specific paths must validate; ignore everything else" | flat `QueryRules` |
+| "This map is a closed object: known keys, no extras" | `Map.KeyedRules` |
+| "Each value of this map / each element of this array must validate" | [`Every`][Every] |
+| "Allow this key but trust its content" | `Map.Keys` (no rule) or `Any{}` inside `KeyedRules` |
+
+The two styles can be mixed inside the same `QueryRules`; use whichever
+fits each location.
 
 ## Nested validation with `Every`
 
@@ -189,12 +242,13 @@ resulting rule with `Required`.
 | type | fields |
 | ---- | ------ |
 | `require` | *(none)* |
+| `any` | *(none)* |
 | `string` | `enum`, `regex`, `minLen`, `maxLen` |
 | `int` | `min`, `max` |
 | `float` | `min`, `max` |
 | `bool` | *(none)* |
 | `array` | `minLen`, `maxLen` |
-| `map` | `keys` |
+| `map` | `keys`, `keyedRules: {key: spec, ...}` |
 | `and` | `of: [spec, ...]` |
 | `or` | `of: [spec, ...]` |
 | `not` | `rule: spec` |
@@ -203,6 +257,27 @@ resulting rule with `Required`.
 Plus the universal meta fields `type` and `required`. Unknown
 fields on a spec are rejected. Field types are checked strictly —
 for example, `min: "0"` is an error, not coerced to `0`.
+
+### Closed object via `map.keyedRules`
+
+The same closed-object check as the Go example above, in YAML:
+
+```yaml
+".":
+  type: map
+  keyedRules:
+    name: { type: string, required: true }
+    age:  { type: int, min: 0, max: 150 }
+    tags:
+      type: every
+      rules:
+        ".": { type: string }
+    meta: { type: any }   # accepted but not validated
+```
+
+Inside `keyedRules`, each entry is a full rule spec, so `required:
+true`, nested `every`, custom registered types, and so on all work
+exactly as they do at the top level.
 
 ### Nested YAML example
 
@@ -368,8 +443,8 @@ reference alongside this guide.
 - **Core:** [`Validate`][Validate], [`ValidateWithPrefix`][ValidateWithPrefix],
   [`QueryRules`][QueryRules], [`Rule`][Rule].
 - **Presence / composition:** [`Require`][Require],
-  [`Required`][Required], [`And`][And], [`Or`][Or], [`Not`][Not],
-  [`Every`][Every].
+  [`Required`][Required], [`Any`][Any], [`And`][And], [`Or`][Or],
+  [`Not`][Not], [`Every`][Every].
 - **Leaf rules:** [`String`][String], [`Int`][Int], [`Float`][Float],
   [`Bool`][Bool], [`Array`][Array], [`Map`][Map].
 - **Helpers:** [`IntPtr`][IntPtr], [`Int64Ptr`][Int64Ptr],
@@ -386,6 +461,7 @@ reference alongside this guide.
 [Rule]: https://pkg.go.dev/github.com/mojatter/tree/schema#Rule
 [Require]: https://pkg.go.dev/github.com/mojatter/tree/schema#Require
 [Required]: https://pkg.go.dev/github.com/mojatter/tree/schema#Required
+[Any]: https://pkg.go.dev/github.com/mojatter/tree/schema#Any
 [And]: https://pkg.go.dev/github.com/mojatter/tree/schema#And
 [Or]: https://pkg.go.dev/github.com/mojatter/tree/schema#Or
 [Not]: https://pkg.go.dev/github.com/mojatter/tree/schema#Not

--- a/schema/doc.go
+++ b/schema/doc.go
@@ -35,6 +35,8 @@
 // # Rule types
 //
 //   - [Require]: fires when the node is Nil.
+//   - [Any]: pass-through; useful as a "key allowed but not validated"
+//     entry inside [Map.KeyedRules].
 //   - [And]: passes when every child passes; collects all errors.
 //   - [Or]: passes when at least one child passes.
 //   - [Not]: passes when the inner rule fails; skips Nil.
@@ -48,7 +50,11 @@
 //   - [Bool]: boolean leaf.
 //   - [Array]: array leaf with optional MinLen/MaxLen. Element rules
 //     go on separate "[]"-suffixed queries.
-//   - [Map]: map leaf with optional Keys allow-list.
+//   - [Map]: map leaf with optional Keys allow-list and per-key
+//     KeyedRules. Either field "closes" the map (unknown keys are
+//     reported); KeyedRules entries also recursively validate each
+//     value, so a single Map rule can describe a strict object
+//     schema without sibling QueryRules entries.
 //
 // [IntPtr], [Int64Ptr], and [Float64Ptr] let you set Min/Max inline
 // without a temporary variable.

--- a/schema/registry.go
+++ b/schema/registry.go
@@ -47,17 +47,18 @@ func NewRegistry() *Registry {
 }
 
 // BuiltinRegistry returns a Registry preloaded with the built-in rule
-// types: require, string, int, float, bool, array, map, and, or,
+// types: require, any, string, int, float, bool, array, map, and, or,
 // not, every.
 func BuiltinRegistry() *Registry {
 	r := NewRegistry()
 	r.Register("require", parseRequireSpec)
+	r.Register("any", parseAnySpec)
 	r.Register("string", parseStringSpec, "enum", "regex", "minLen", "maxLen")
 	r.Register("int", parseIntSpec, "min", "max")
 	r.Register("float", parseFloatSpec, "min", "max")
 	r.Register("bool", parseBoolSpec)
 	r.Register("array", parseArraySpec, "minLen", "maxLen")
-	r.Register("map", parseMapSpec, "keys")
+	r.Register("map", parseMapSpec, "keys", "keyedRules")
 	r.Register("and", parseAndSpec, "of")
 	r.Register("or", parseOrSpec, "of")
 	r.Register("not", parseNotSpec, "rule")
@@ -180,6 +181,10 @@ func parseRequireSpec(_ tree.Node, _ *Registry) (Rule, error) {
 	return Require{}, nil
 }
 
+func parseAnySpec(_ tree.Node, _ *Registry) (Rule, error) {
+	return Any{}, nil
+}
+
 func parseStringSpec(spec tree.Node, _ *Registry) (Rule, error) {
 	r := String{}
 	var err error
@@ -246,14 +251,48 @@ func parseArraySpec(spec tree.Node, _ *Registry) (Rule, error) {
 	return r, nil
 }
 
-func parseMapSpec(spec tree.Node, _ *Registry) (Rule, error) {
+func parseMapSpec(spec tree.Node, reg *Registry) (Rule, error) {
 	r := Map{}
 	ks, err := optStringSlice(spec, "keys")
 	if err != nil {
 		return nil, err
 	}
 	r.Keys = ks
+	kr, err := optKeyedRules(spec, "keyedRules", reg)
+	if err != nil {
+		return nil, err
+	}
+	r.KeyedRules = kr
 	return r, nil
+}
+
+// optKeyedRules parses an optional map field whose value is itself
+// a map of key -> rule spec. Each entry is parsed via reg.Parse so
+// nested rule type errors are aggregated and prefixed with
+// "<key>.<entry>:".
+func optKeyedRules(spec tree.Node, key string, reg *Registry) (map[string]Rule, error) {
+	n := spec.Get(key)
+	if n.IsNil() {
+		return nil, nil
+	}
+	if !n.Type().IsMap() {
+		return nil, fmt.Errorf("%q must be map, got %s", key, n.Type())
+	}
+	m := n.Map()
+	out := make(map[string]Rule, len(m))
+	var errs []error
+	for _, k := range m.Keys() {
+		r, err := reg.Parse(m[k])
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s.%s: %w", key, k, err))
+			continue
+		}
+		out[k] = r
+	}
+	if len(errs) > 0 {
+		return nil, joinLimited(errs, reg.MaxReportedErrors)
+	}
+	return out, nil
 }
 
 func parseAndSpec(spec tree.Node, reg *Registry) (Rule, error) {

--- a/schema/registry_test.go
+++ b/schema/registry_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBuiltinRegistry(t *testing.T) {
 	r := BuiltinRegistry()
-	wantTypes := []string{"require", "string", "int", "float", "bool", "array", "map", "and", "or", "not"}
+	wantTypes := []string{"require", "any", "string", "int", "float", "bool", "array", "map", "and", "or", "not", "every"}
 	for _, name := range wantTypes {
 		if _, ok := r.entries[name]; !ok {
 			t.Errorf("BuiltinRegistry missing %q", name)
@@ -122,6 +122,21 @@ func TestRegistry_Parse(t *testing.T) {
 			wantErrs: []string{`"keys"[1] must be string`},
 		},
 		{
+			caseName: "map keyedRules not a map",
+			spec:     tree.Map{"type": tree.V("map"), "keyedRules": tree.A("a")},
+			wantErrs: []string{`"keyedRules" must be map, got array`},
+		},
+		{
+			caseName: "map keyedRules nested rule error",
+			spec: tree.Map{
+				"type": tree.V("map"),
+				"keyedRules": tree.Map{
+					"name": tree.Map{"type": tree.V("bogus")},
+				},
+			},
+			wantErrs: []string{`keyedRules.name: unknown rule type "bogus"`},
+		},
+		{
 			caseName: "and missing of",
 			spec:     tree.Map{"type": tree.V("and")},
 			wantErrs: []string{"and: 'of' is required"},
@@ -207,6 +222,72 @@ func TestRegistry_Parse_RequiredFalseNotWrapped(t *testing.T) {
 	// Not wrapped: Nil must be OK.
 	if err := rule.Validate(tree.Nil, ".x"); err != nil {
 		t.Errorf("required:false should not wrap; got %v", err)
+	}
+}
+
+func TestRegistry_Parse_Any(t *testing.T) {
+	r := BuiltinRegistry()
+	rule, err := r.Parse(tree.Map{"type": tree.V("any")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := rule.(Any); !ok {
+		t.Errorf("got %T; want Any", rule)
+	}
+	// Any passes for every node, including Nil.
+	for _, n := range []tree.Node{tree.Nil, tree.V("x"), tree.V(1), tree.A(), tree.Map{}} {
+		if err := rule.Validate(n, ".x"); err != nil {
+			t.Errorf("Any on %v: unexpected %v", n, err)
+		}
+	}
+}
+
+func TestRegistry_Parse_Map_KeyedRules(t *testing.T) {
+	r := BuiltinRegistry()
+	spec := tree.Map{
+		"type": tree.V("map"),
+		"keys": tree.A("legacy"),
+		"keyedRules": tree.Map{
+			"name": tree.Map{"type": tree.V("string"), "required": tree.V(true)},
+			"age":  tree.Map{"type": tree.V("int"), "min": tree.V(0)},
+			"meta": tree.Map{"type": tree.V("any")},
+		},
+	}
+	rule, err := r.Parse(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mr, ok := rule.(Map)
+	if !ok {
+		t.Fatalf("got %T; want Map", rule)
+	}
+	if len(mr.Keys) != 1 || mr.Keys[0] != "legacy" {
+		t.Errorf("Keys = %v; want [legacy]", mr.Keys)
+	}
+	for _, k := range []string{"name", "age", "meta"} {
+		if _, ok := mr.KeyedRules[k]; !ok {
+			t.Errorf("KeyedRules missing %q", k)
+		}
+	}
+	// Round-trip: validate sample data through the parsed rule.
+	doc := tree.Map{
+		"age":    tree.V(-1),         // < min
+		"meta":   tree.V("anything"), // Any passes
+		"legacy": tree.V("ok"),       // listed in Keys
+		"bogus":  tree.V(1),          // unknown
+	}
+	err = mr.Validate(doc, ".x")
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	for _, w := range []string{
+		".x: unknown key \"bogus\"",
+		".x.age: value -1 less than min 0",
+		".x.name: required",
+	} {
+		if !strings.Contains(err.Error(), w) {
+			t.Errorf("error %q missing %q", err.Error(), w)
+		}
 	}
 }
 

--- a/schema/rules.go
+++ b/schema/rules.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"regexp"
 	"slices"
@@ -38,6 +39,15 @@ func Int64Ptr(v int64) *int64 { return tree.Int64Ptr(v) }
 //
 // Deprecated: Use [tree.Float64Ptr].
 func Float64Ptr(v float64) *float64 { return tree.Float64Ptr(v) }
+
+// Any is a no-op rule that always passes. It is useful inside a
+// [Map.KeyedRules] entry to declare a key as "allowed but not
+// validated", so the map's allow-list still rejects unknown keys
+// while letting the listed key carry any value.
+type Any struct{}
+
+// Validate implements Rule.
+func (Any) Validate(tree.Node, string) error { return nil }
 
 // Require fires an error when the node is tree.Nil (query matched
 // nothing). It is the only rule that treats Nil as a violation.
@@ -294,11 +304,23 @@ func (r Array) Validate(n tree.Node, q string) error {
 	return nil
 }
 
-// Map matches a map. When Keys is non-empty, any key outside the
-// allow-list is reported (one error per unknown key, keys sorted for
-// stable output).
+// Map matches a map with optional allow-list and per-key rules.
+//
+// When Keys or KeyedRules is non-empty, the map becomes "closed":
+// any key not in (Keys ∪ KeyedRules-keys) is reported as
+// "unknown key". Keys lists names that are accepted without further
+// validation; KeyedRules attaches a Rule to specific keys, with the
+// rule receiving tree.Nil when the key is absent (so [Required]
+// fires for missing required fields).
+//
+// When both Keys and KeyedRules are empty, only the type check runs
+// (any keys are accepted).
+//
+// Errors are reported with sorted keys for stable output. Per-key
+// rule errors carry the concrete sub-path (q + "." + key).
 type Map struct {
-	Keys []string
+	Keys       []string
+	KeyedRules map[string]Rule
 }
 
 // Validate implements Rule.
@@ -309,15 +331,33 @@ func (r Map) Validate(n tree.Node, q string) error {
 	if !n.Type().IsMap() {
 		return fmt.Errorf("%s: expected map, got %s", q, n.Type())
 	}
-	if len(r.Keys) == 0 {
+	if len(r.Keys) == 0 && len(r.KeyedRules) == 0 {
 		return nil
 	}
 	m := n.Map()
 	var errs []error
 	for _, k := range m.Keys() {
-		if !slices.Contains(r.Keys, k) {
-			errs = append(errs, fmt.Errorf("%s: unknown key %q", q, k))
+		if slices.Contains(r.Keys, k) {
+			continue
+		}
+		if _, ok := r.KeyedRules[k]; ok {
+			continue
+		}
+		errs = append(errs, fmt.Errorf("%s: unknown key %q", q, k))
+	}
+	for _, k := range slices.Sorted(maps.Keys(r.KeyedRules)) {
+		if err := r.KeyedRules[k].Validate(m.Get(k), keyPath(q, k)); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// keyPath joins a parent display path q with a child key k, avoiding
+// the "..key" double-dot when q is the root marker ".".
+func keyPath(q, k string) string {
+	if q == "." {
+		return "." + k
+	}
+	return q + "." + k
 }

--- a/schema/rules_test.go
+++ b/schema/rules_test.go
@@ -13,6 +13,27 @@ func intPtr(v int) *int         { return &v }
 func int64Ptr(v int64) *int64   { return &v }
 func f64Ptr(v float64) *float64 { return &v }
 
+func TestAny(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		n        tree.Node
+	}{
+		{caseName: "nil", n: tree.Nil},
+		{caseName: "string", n: tree.V("x")},
+		{caseName: "number", n: tree.V(42)},
+		{caseName: "bool", n: tree.V(true)},
+		{caseName: "map", n: tree.Map{"a": tree.V(1)}},
+		{caseName: "array", n: tree.A("x", "y")},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			if err := (Any{}).Validate(tc.n, ".x"); err != nil {
+				t.Errorf("Any: unexpected %v", err)
+			}
+		})
+	}
+}
+
 func TestRequire(t *testing.T) {
 	if err := (Require{}).Validate(tree.Nil, ".x"); err == nil {
 		t.Error("Require on Nil: want error")
@@ -324,6 +345,96 @@ func TestMap(t *testing.T) {
 			rule:     Map{Keys: []string{"a"}},
 			n:        tree.Map{"a": tree.V(1), "c": tree.V(2), "b": tree.V(3)},
 			wantErrs: []string{`.x: unknown key "b"`, `.x: unknown key "c"`},
+		},
+		{
+			caseName: "keyed rules pass on valid values",
+			rule: Map{KeyedRules: map[string]Rule{
+				"name": String{},
+				"age":  Int{Min: int64Ptr(0)},
+			}},
+			n: tree.Map{"name": tree.V("alice"), "age": tree.V(30)},
+		},
+		{
+			caseName: "keyed rules: unknown key beyond declared rules",
+			rule: Map{KeyedRules: map[string]Rule{
+				"name": String{},
+			}},
+			n:        tree.Map{"name": tree.V("alice"), "bogus": tree.V(1)},
+			wantErrs: []string{`.x: unknown key "bogus"`},
+		},
+		{
+			caseName: "keyed rules: per-key violation reported with sub-path",
+			rule: Map{KeyedRules: map[string]Rule{
+				"name": String{},
+				"age":  Int{Min: int64Ptr(0)},
+			}},
+			n:        tree.Map{"name": tree.V(42), "age": tree.V(-1)},
+			wantErrs: []string{".x.age: value -1 less than min 0", ".x.name: expected string, got number"},
+		},
+		{
+			caseName: "keyed rules: missing optional key passes",
+			rule: Map{KeyedRules: map[string]Rule{
+				"name": String{},
+				"age":  Int{},
+			}},
+			n: tree.Map{"name": tree.V("alice")}, // age omitted, no Required
+		},
+		{
+			caseName: "keyed rules: missing required key reported",
+			rule: Map{KeyedRules: map[string]Rule{
+				"name": Required(String{}),
+				"age":  Int{},
+			}},
+			n:        tree.Map{"age": tree.V(30)},
+			wantErrs: []string{".x.name: required"},
+		},
+		{
+			caseName: "Keys + KeyedRules union becomes the allow-list",
+			rule: Map{
+				Keys: []string{"legacy"},
+				KeyedRules: map[string]Rule{
+					"name": String{},
+				},
+			},
+			n: tree.Map{"name": tree.V("alice"), "legacy": tree.V("anything")},
+		},
+		{
+			caseName: "Keys + KeyedRules: still rejects keys not in either",
+			rule: Map{
+				Keys: []string{"legacy"},
+				KeyedRules: map[string]Rule{
+					"name": String{},
+				},
+			},
+			n:        tree.Map{"name": tree.V("alice"), "bogus": tree.V(1)},
+			wantErrs: []string{`.x: unknown key "bogus"`},
+		},
+		{
+			caseName: "Any inside KeyedRules: key allowed without per-value check",
+			rule: Map{KeyedRules: map[string]Rule{
+				"name": String{},
+				"meta": Any{}, // any value type is fine
+			}},
+			n: tree.Map{"name": tree.V("alice"), "meta": tree.Map{"created": tree.V("2026")}},
+		},
+		{
+			caseName: "nested KeyedRules: child Map runs its own validation",
+			rule: Map{KeyedRules: map[string]Rule{
+				"server": Map{KeyedRules: map[string]Rule{
+					"port": Required(Int{Min: int64Ptr(1)}),
+				}},
+			}},
+			n:        tree.Map{"server": tree.Map{}}, // missing port
+			wantErrs: []string{".x.server.port: required"},
+		},
+		{
+			caseName: "nested KeyedRules: parent Nil short-circuits children",
+			rule: Map{KeyedRules: map[string]Rule{
+				"server": Map{KeyedRules: map[string]Rule{
+					"port": Required(Int{}),
+				}},
+			}},
+			n: tree.Map{}, // server absent: child Required must NOT fire
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

- Add `Map.KeyedRules map[string]Rule` so a single `Map` rule can express a strict object schema (allow-list + per-key rules) in one place, instead of pairing `Map{Keys: [...]}` with sibling `.foo` rules in the surrounding `QueryRules`.
- Add `Any` rule (no-op) so a key can be declared "allowed but not validated" inside `KeyedRules`.
- Wire both into the YAML registry: `type: any` and `map.keyedRules: {key: spec, ...}`. `keyedRules` entries recurse through `reg.Parse`, so `required: true`, nested `every`, custom rule types, etc. all work.
- Document the new shape in `schema/doc.go` and `docs/schema.md` (new "Closed object schemas with `Map.KeyedRules`" section + YAML example + selection table).

Motivated by fasthttpd reporting that the `Map{Keys: [...]}` allow-list duplicated the per-field rule keys, with no enforcement that the two stay in sync.

Purely additive — `Map{Keys: [...]}` existing behaviour and YAML `type: map, keys: [...]` specs are unchanged.

## Test plan

- [x] `go test ./...` passes (new cases: `Any` over every node type; `Map.KeyedRules` for valid / unknown / per-key violation / missing optional / missing required / `Keys` + `KeyedRules` union / `Any` inside / nested child Map / parent-Nil short-circuit)
- [x] `go vet ./...` clean
- [x] YAML round-trip test parses a `map` spec with `keys` + `keyedRules` (including `any`) and runs `Validate` end-to-end against sample data
- [x] Backwards compatibility: existing `Map{Keys: ...}` and `type: map, keys: [...]` cases still pass