### PR TITLE
refactor(merge): Pre-1.0 cleanup and add MergeOptionFromString helper

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -1,9 +1,14 @@
 package tree
 
+import (
+	"fmt"
+	"strings"
+)
+
 // MergeOption represents different merge strategies for combining nodes.
 type MergeOption int
 
-var (
+const (
 	// MergeOptionDefault merges with the following default rules.
 	// For examples:
 	// - {"a": 1, "b": 2} and {"a": 3, "c": 4} merges to {"a": 1, "b": 2, "c": 4}
@@ -43,17 +48,23 @@ var (
 	// - "a" and "b" merges to "b"
 	MergeOptionReplace MergeOption = MergeOptionReplaceMap | MergeOptionReplaceArray
 	// MergeOptionAppend acts when both are arrays and append them.
-	// It takes precedence over MergeOptionOverride and MergeOptionReplace.
+	// Inside array merging this is checked before Override and Replace,
+	// so when both operands are arrays Append wins over those flags.
 	// For examples:
 	// - [1, 2, 3] and [4, 5] merges to [1, 2, 3, 4, 5]
 	MergeOptionAppend MergeOption = 0b010000
 	// MergeOptionSlurp acts on an array or value and converts it to an array and
-	// merges it, even if the value is not an array.
-	// It takes precedence over MergeOptionOverride and MergeOptionReplace.
+	// merges it, even if the value is not an array. When the two operands have
+	// non-matching types (e.g. array vs scalar) it wins over Override and Replace
+	// because the slurp wrapping happens before the type-mismatch fallback.
+	// Inside Map merging Slurp follows the same per-key recursion as
+	// MergeOptionOverrideMap, so leaf type-mismatched values are wrapped into
+	// an array (see "Slurp Map Map" example below).
 	// For examples:
 	// - [1, 2, 3] and [4, 5] merges to [1, 2, 3, 4, 5]
 	// - [1, 2, 3] and 4 merges to [1, 2, 3, 4]
 	// - 1 and 2 merges to [1, 2]
+	// - {"a": 1} and {"a": 2} merges to {"a": [1, 2]}
 	MergeOptionSlurp MergeOption = 0b100000
 )
 
@@ -97,9 +108,68 @@ func (o MergeOption) isSlurp() bool {
 	return o&MergeOptionSlurp == MergeOptionSlurp
 }
 
-// Merge merges two nodes with MergeOption.
-// If you do not want to change the state of the node given as an argument, use CloneDeep.
-// ex: merged := Merge(CloneDeep(a), CloneDeep(b), opts)
+// MergeOptionFromString parses a comma-separated merge strategy spec
+// into a MergeOption. Recognised names map directly to the exported
+// MergeOption* values:
+//
+//   - "default"        — MergeOptionDefault (zero value)
+//   - "override"       — MergeOptionOverride (= override-map | override-array)
+//   - "override-map"   — MergeOptionOverrideMap
+//   - "override-array" — MergeOptionOverrideArray
+//   - "replace"        — MergeOptionReplace (= replace-map | replace-array)
+//   - "replace-map"    — MergeOptionReplaceMap
+//   - "replace-array"  — MergeOptionReplaceArray
+//   - "append"         — MergeOptionAppend
+//   - "slurp"          — MergeOptionSlurp
+//
+// Multiple names may be combined with commas: "override,append" yields
+// MergeOptionOverride | MergeOptionAppend. Whitespace around each name
+// is trimmed. An empty spec returns MergeOptionDefault. An unknown name
+// produces a non-nil error and a zero MergeOption.
+//
+// Intended for CLI / config consumers (e.g. tq's --merge flag) so the
+// option-name vocabulary lives next to the option definitions.
+func MergeOptionFromString(spec string) (MergeOption, error) {
+	if spec == "" {
+		return MergeOptionDefault, nil
+	}
+	var opts MergeOption
+	for name := range strings.SplitSeq(spec, ",") {
+		name = strings.TrimSpace(name)
+		switch name {
+		case "default":
+			// no flag bits
+		case "override":
+			opts |= MergeOptionOverride
+		case "override-map":
+			opts |= MergeOptionOverrideMap
+		case "override-array":
+			opts |= MergeOptionOverrideArray
+		case "replace":
+			opts |= MergeOptionReplace
+		case "replace-map":
+			opts |= MergeOptionReplaceMap
+		case "replace-array":
+			opts |= MergeOptionReplaceArray
+		case "append":
+			opts |= MergeOptionAppend
+		case "slurp":
+			opts |= MergeOptionSlurp
+		default:
+			return 0, fmt.Errorf("unknown merge strategy %q", name)
+		}
+	}
+	return opts, nil
+}
+
+// Merge merges two nodes with MergeOption. The opts value propagates
+// recursively into every nested merge call, so a flag set at the top
+// level (e.g. Append) also applies to arrays found at any depth.
+//
+// Merge mutates a in place and may return either a or b depending on
+// the rules. If you need to preserve the inputs, clone before calling:
+//
+//	merged := tree.Merge(tree.CloneDeep(a), tree.CloneDeep(b), opts)
 func Merge(a, b Node, opts MergeOption) Node {
 	if a.Type().IsMap() {
 		if b.Type().IsMap() {
@@ -125,7 +195,13 @@ func Merge(a, b Node, opts MergeOption) Node {
 }
 
 // mergeNoMatchType handles merging when node types don't match.
-// Returns the appropriate node based on merge options.
+// Returns b if any Override*/Replace* flag is set, otherwise a.
+//
+// Note: the predicate is "any override-or-replace flag", not the
+// specific one matching the operand types. Setting only
+// MergeOptionOverrideArray therefore still causes a Map vs scalar
+// merge to choose b. Distinguishing per-shape override on type
+// mismatch would be a behaviour change; revisit at v1.0.
 func mergeNoMatchType(a Node, b Node, opts MergeOption) Node {
 	if opts.isOverrideValue() || opts.isReplaceValue() {
 		return b
@@ -142,6 +218,8 @@ func mergeArray(a, b Array, opts MergeOption) Array {
 	if opts.isOverrideArray() {
 		for i, v := range b {
 			if i < len(a) {
+				// Set only fails on out-of-range index; the i < len(a)
+				// guard above makes that impossible here.
 				_ = a.Set(i, Merge(a[i], v, opts))
 			} else {
 				a = append(a, v)

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,6 +1,7 @@
 package tree
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -97,6 +98,72 @@ func TestMergeOption(t *testing.T) {
 		t.Run(tc.caseName, func(t *testing.T) {
 			if got := tc.is(); got != tc.want {
 				t.Errorf("got %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeOptionFromString(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		spec     string
+		want     MergeOption
+		wantErr  string // substring; empty means success
+	}{
+		{caseName: "empty is default", spec: "", want: MergeOptionDefault},
+		{caseName: "default name", spec: "default", want: MergeOptionDefault},
+		{caseName: "override", spec: "override", want: MergeOptionOverride},
+		{caseName: "override-map", spec: "override-map", want: MergeOptionOverrideMap},
+		{caseName: "override-array", spec: "override-array", want: MergeOptionOverrideArray},
+		{caseName: "replace", spec: "replace", want: MergeOptionReplace},
+		{caseName: "replace-map", spec: "replace-map", want: MergeOptionReplaceMap},
+		{caseName: "replace-array", spec: "replace-array", want: MergeOptionReplaceArray},
+		{caseName: "append", spec: "append", want: MergeOptionAppend},
+		{caseName: "slurp", spec: "slurp", want: MergeOptionSlurp},
+		{
+			caseName: "combined override and append",
+			spec:     "override,append",
+			want:     MergeOptionOverride | MergeOptionAppend,
+		},
+		{
+			caseName: "combined with whitespace",
+			spec:     " override-map , append ",
+			want:     MergeOptionOverrideMap | MergeOptionAppend,
+		},
+		{
+			caseName: "combined three options",
+			spec:     "override-map,replace-array,slurp",
+			want:     MergeOptionOverrideMap | MergeOptionReplaceArray | MergeOptionSlurp,
+		},
+		{
+			caseName: "duplicate names are idempotent",
+			spec:     "append,append",
+			want:     MergeOptionAppend,
+		},
+		{caseName: "unknown name", spec: "bogus", wantErr: `unknown merge strategy "bogus"`},
+		{caseName: "unknown after valid stops at first error", spec: "override,bogus", wantErr: `unknown merge strategy "bogus"`},
+		{caseName: "underscore form not accepted", spec: "override_map", wantErr: `unknown merge strategy "override_map"`},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			got, err := MergeOptionFromString(tc.spec)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tc.want {
+					t.Errorf("got %b; want %b", got, tc.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+			if got != 0 {
+				t.Errorf("on error want zero option, got %b", got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Pre-flight cleanup of `merge.go` before exposing `Merge` via tq's upcoming `--merge` flag (next PR). Three orthogonal threads bundled into one:

- **Const conversion** — `MergeOption*` values were declared with `var`, so `tree.MergeOptionDefault = 999` was legal and any importing package could rewrite the constants. The bit literals are compile-time, so `const` works as a drop-in.
- **Doc clarifications** (no behaviour change):
  - `MergeOptionAppend` precedence is now scoped (*"inside array merging this is checked before Override and Replace"*) instead of the bare *"takes precedence"*.
  - `MergeOptionSlurp` likewise gets a scoped precedence note, and the previously undocumented map-side behaviour (Slurp recurses through `mergeMap` like `OverrideMap`, leaf type-mismatched values get array-wrapped) is now spelled out, with a `{"a": 1} and {"a": 2} → {"a": [1, 2]}` example.
  - `Merge` doc now says explicitly that options propagate recursively, and that the function mutates `a` in place — moved from the original *"if you do not want to change the state…use CloneDeep"* to a clearer **Merge mutates a in place** statement plus the `tree.CloneDeep(a)` example.
  - `mergeNoMatchType` now flags that its `isOverrideValue()` predicate is "any override-or-replace flag", so e.g. `MergeOptionOverrideArray` alone causes a Map vs scalar merge to choose `b` — noted as a v1.0 candidate behaviour change.
  - `_ = a.Set(...)` in `mergeArray` now has a one-line comment recording why the error is safe to drop (the `i < len(a)` guard above).
- **`MergeOptionFromString` helper added** — parses comma-separated strategy names (`"override"`, `"override,append"`, `" override-map , slurp "`, …) into a `MergeOption`. Uses `strings.SplitSeq` (Go 1.24 iterator-style). Intended for tq's `--merge=` flag and any other CLI / config consumer that shouldn't be re-encoding the option vocabulary itself. Recognised names map directly to the exported `MergeOption*` values; unknown names error out with the offending string.

Backwards compatibility: no exported signatures changed. `var (...)` → `const (...)` does not affect any code that doesn't try to assign to those identifiers (which would have been broken-by-design anyway).

## Test plan

- [x] `go test ./...` passes (existing tests unchanged + 17 new cases for `MergeOptionFromString`)
- [x] `go vet ./...` clean
- [x] `MergeOptionFromString` covers: every single name (9 cases), combinations including whitespace and three-way combos (3 cases), idempotent duplicates, empty-string default, three error paths (unknown standalone, unknown after valid, underscore form not accepted)
- [x] `tree.Equal`-based mutation guard already in `TestMerge` continues to pass — confirms the doc change about in-place mutation matches actual behaviour