### PR TITLE
feat(tq): Add --merge flag for combining multiple inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Tree is a simple structure for dealing with dynamic or unknown JSON/YAML in Go.
 - [Edit](#edit)
 - [Schema](#schema)
 - [tq](#tq)
+  - [Merge multiple inputs](#merge-multiple-inputs)
 - [Contributing](#contributing)
 - [Third-party library licenses](#third-party-library-licenses)
 
@@ -36,7 +37,6 @@ Tree is a simple structure for dealing with dynamic or unknown JSON/YAML in Go.
 ## Road to 1.0
 
 - Placeholders in query.
-- Merge support in tq.
 
 ## Syntax
 
@@ -443,22 +443,23 @@ Usage:
   tq [flags] [query] ([file...])
 
 Flags:
-  -c, --color                  output with colors
-  -e, --edit stringArray       edit expression
-  -x, --expand                 expand results
-  -h, --help                   help for tq
-  -U, --inplace                update files, inplace
-  -i, --input-format string    input format (json or yaml)
-  -j, --input-json             alias --input-format json
-  -y, --input-yaml             alias --input-format yaml
-  -O, --output string          output file
-  -o, --output-format string   output format (json or yaml, default json)
-  -J, --output-json            alias --output-format json
-  -Y, --output-yaml            alias --output-format yaml
-  -r, --raw                    output raw strings
-  -s, --slurp                  slurp all results into an array
-  -t, --template string        golang text/template string
-  -v, --version                print version
+  -c, --color                      output with colors
+  -e, --edit stringArray           edit expression
+  -x, --expand                     expand results
+  -h, --help                       help for tq
+  -U, --inplace                    update files, inplace
+  -i, --input-format string        input format (json or yaml)
+  -j, --input-json                 alias --input-format json
+  -y, --input-yaml                 alias --input-format yaml
+  -m, --merge string[="default"]   merge inputs (optional strategy: default, override, replace, append, slurp; combine with comma)
+  -O, --output string              output file
+  -o, --output-format string       output format (json or yaml, default json)
+  -J, --output-json                alias --output-format json
+  -Y, --output-yaml                alias --output-format yaml
+  -r, --raw                        output raw strings
+  -s, --slurp                      slurp all results into an array
+  -t, --template string            golang text/template string
+  -v, --version                    print version
 
 Examples:
   % echo '{"colors": ["red", "green", "blue"]}' | tq '.colors[0]'
@@ -482,6 +483,64 @@ Examples:
   [{"author": "Tolkien"}]
 
 ```
+
+### Merge multiple inputs
+
+The `--merge` (`-m`) flag folds every document from every input file
+into one tree before applying the optional query / `--edit`. The
+positional layout becomes `tq --merge [strategy] [query] file...`, and
+since most merges have no query you can write the natural form:
+
+```sh
+tq --merge a.yaml b.yaml > merged.yaml
+```
+
+When `--merge` is set and the first positional argument doesn't look
+like a query (i.e. doesn't start with `.` or `[`), every positional is
+treated as a file. Pass an explicit `.` only when you also want a
+query.
+
+#### Strategies
+
+`--merge` takes an optional value; omitting it gives the default
+strategy. Multiple strategies can be combined with commas
+(`--merge=override-map,append`).
+
+| Name | Maps | Arrays | Type-mismatched values |
+|---|---|---|---|
+| `default` (no flag) | shallow: keep `a`, add `b`'s missing top-level keys | overlay trailing tail of `b` | keep `a` |
+| `override` | recursive: `b` wins on conflicts | per-index `b` wins, longer `b` extends | replace with `b` |
+| `override-map` | recursive map override only | (default array behaviour) | (depends) |
+| `override-array` | (default map behaviour) | per-index `b` wins | (depends) |
+| `replace` | top-level: take `b` entirely | take `b` entirely | take `b` |
+| `replace-map` | take `b`'s map entirely | (default array behaviour) | (depends) |
+| `replace-array` | (default map behaviour) | take `b`'s array entirely | (depends) |
+| `append` | (default — see note) | concat `a` then `b` | (depends) |
+| `slurp` | recurse like `override-map`; leaf type-mismatch wraps into array | concat `a` then `b` | wrap into array |
+
+Note that `default` and `append` alone are **shallow** at the map
+level — to also recurse into nested maps and append nested arrays,
+combine them: `--merge=override-map,append`.
+
+#### Examples
+
+```sh
+# Layered config: later file's leaves win, scalar values get overridden
+tq --merge=override base.yaml override.yaml > effective.yaml
+
+# Combine list-style configs from multiple sources, keeping all entries
+tq --merge=override-map,append rules.d/*.yaml > all-rules.yaml
+
+# Apply a query after merging
+tq --merge=override .servers cluster-base.yaml cluster-override.yaml
+
+# Edit on top of the merge
+tq --merge -e '.metadata.merged = true' a.yaml b.yaml
+```
+
+`--merge` cannot be combined with `--inplace` (multiple inputs vs. a
+single write target) or `--slurp` (both accumulate, with conflicting
+semantics).
 
 ### for jq user
 

--- a/cmd/tq/main.go
+++ b/cmd/tq/main.go
@@ -96,23 +96,24 @@ func newStdinReader() (io.ReadSeekCloser, error) {
 }
 
 type runner struct {
-	flagSet      *pflag.FlagSet
-	isVersion    bool
-	isHelp       bool
-	isExpand     bool
-	isSlurp      bool
-	isRaw        bool
-	isInplace    bool
-	isColor      bool
-	isInputJSON  bool
-	isInputYAML  bool
-	isOutputJSON bool
-	isOutputYAML bool
-	outputFile   string
-	tmplText     string
-	inputFormat  string
-	outputFormat string
-	editExprs    []string
+	flagSet       *pflag.FlagSet
+	isVersion     bool
+	isHelp        bool
+	isExpand      bool
+	isSlurp       bool
+	isRaw         bool
+	isInplace     bool
+	isColor       bool
+	isInputJSON   bool
+	isInputYAML   bool
+	isOutputJSON  bool
+	isOutputYAML  bool
+	outputFile    string
+	tmplText      string
+	inputFormat   string
+	outputFormat  string
+	editExprs     []string
+	mergeStrategy string
 
 	tmpl             *template.Template
 	stderr           io.Writer
@@ -120,6 +121,16 @@ type runner struct {
 	guessFormat      string
 	outputYAMLCalled int
 	slurpResults     tree.Array
+	mergeOption      tree.MergeOption
+	queryExpr        string
+}
+
+// looksLikeQuery reports whether s looks like a tree query expression
+// rather than a file path. Used by --merge mode to decide whether the
+// first positional argument is a query or a file. tree queries always
+// begin with "." (path) or "[" (filter / array index).
+func looksLikeQuery(s string) bool {
+	return strings.HasPrefix(s, ".") || strings.HasPrefix(s, "[")
 }
 
 func newRunner() *runner {
@@ -150,6 +161,8 @@ func (r *runner) initFlagSet(args []string) error {
 	s.StringVarP(&r.inputFormat, "input-format", "i", "", "input format (json or yaml)")
 	s.StringVarP(&r.outputFormat, "output-format", "o", "", "output format (json or yaml, default json)")
 	s.StringArrayVarP(&r.editExprs, "edit", "e", nil, "edit expression")
+	s.StringVarP(&r.mergeStrategy, "merge", "m", "", "merge inputs (optional strategy: default, override, replace, append, slurp; combine with comma)")
+	s.Lookup("merge").NoOptDefVal = "default"
 	s.Usage = func() {
 		_, _ = fmt.Fprintf(r.stderr, "%s\n\nUsage:\n  %s\n\n", desc, usage)
 		_, _ = fmt.Fprintln(r.stderr, "Flags:")
@@ -176,9 +189,22 @@ func (r *runner) run(args []string) error {
 		_, _ = fmt.Fprintln(r.out, tree.VERSION)
 		return nil
 	}
-	if r.isHelp || (r.flagSet.Arg(0) == "" && len(r.editExprs) == 0) {
+	if r.isHelp || (r.flagSet.Arg(0) == "" && len(r.editExprs) == 0 && r.mergeStrategy == "") {
 		r.flagSet.Usage()
 		return nil
+	}
+	if r.mergeStrategy != "" {
+		opt, err := tree.MergeOptionFromString(r.mergeStrategy)
+		if err != nil {
+			return fmt.Errorf("--merge: %w", err)
+		}
+		r.mergeOption = opt
+		if r.isInplace {
+			return errors.New("--merge cannot be combined with --inplace")
+		}
+		if r.isSlurp {
+			return errors.New("--merge cannot be combined with --slurp")
+		}
 	}
 	if r.tmplText != "" {
 		tmpl, err := template.New("").Parse(r.tmplText)
@@ -189,8 +215,19 @@ func (r *runner) run(args []string) error {
 	}
 
 	var filenames []string
-	if args := r.flagSet.Args(); len(args) > 1 {
-		filenames = args[1:]
+	posArgs := r.flagSet.Args()
+	if r.mergeStrategy != "" && len(posArgs) > 0 && !looksLikeQuery(posArgs[0]) {
+		// In --merge mode, accept the conventional "tq --merge a.yaml b.yaml"
+		// (no query). Treat all positionals as files when the first one
+		// doesn't look like a tree query.
+		filenames = posArgs
+	} else {
+		if len(posArgs) > 0 {
+			r.queryExpr = posArgs[0]
+		}
+		if len(posArgs) > 1 {
+			filenames = posArgs[1:]
+		}
 	}
 	if len(filenames) == 0 {
 		if term.IsTerminal(0) {
@@ -206,6 +243,9 @@ func (r *runner) run(args []string) error {
 			return err
 		}
 		r.out = out
+	}
+	if r.mergeStrategy != "" {
+		return r.evaluateMergeFiles(newInputFiles(filenames))
 	}
 	return r.evaluateInputFiles(newInputFiles(filenames))
 }
@@ -255,23 +295,81 @@ func (r *runner) evaluateInputFiles(f *inputFiles) error {
 	return r.evaluateInputFiles(f)
 }
 
+// evaluateMergeFiles reads every doc from every input file and folds
+// them with tree.Merge in left-to-right order, then runs the usual
+// edit/query/output pipeline once on the merged result. With multiple
+// docs in the same file (e.g. YAML "---" separators) the docs are
+// merged in the order they appear, before merging into the next file.
+func (r *runner) evaluateMergeFiles(f *inputFiles) error {
+	var acc tree.Node
+	accSet := false
+	handle := func(n tree.Node) error {
+		if !accSet {
+			acc = n
+			accSet = true
+			return nil
+		}
+		acc = tree.Merge(acc, n, r.mergeOption)
+		return nil
+	}
+	for {
+		in, err := f.nextReader()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		filename := f.filename
+		err = r.parseStream(in, handle)
+		_ = in.Close()
+		if err != nil {
+			if filename == filenameStdin {
+				filename = "STDIN"
+			}
+			return fmt.Errorf("failed to evaluate %s: %w", filename, err)
+		}
+	}
+	if !accSet {
+		return nil
+	}
+	return r.evaluateNode(acc)
+}
+
 func (r *runner) evaluate(in io.ReadSeekCloser) error {
+	if err := r.parseStream(in, r.evaluateNode); err != nil {
+		return err
+	}
+	if len(r.slurpResults) > 0 {
+		defer func() { r.slurpResults = nil }()
+
+		return r.output(r.slurpResults)
+	}
+	return nil
+}
+
+// parseStream reads in, dispatches to the JSON or YAML parser based on
+// the input-format flags (or by trying both when neither is forced),
+// and invokes handle for every parsed node. Decoding the input as one
+// format and falling back to the other is preserved here so callers
+// (evaluate, evaluateMergeFiles) get the same auto-detection.
+func (r *runner) parseStream(in io.ReadSeekCloser, handle func(tree.Node) error) error {
 	if r.inputFormat == "json" || r.isInputJSON {
-		return r.evaluateJSON(in)
+		return r.parseJSON(in, handle)
 	}
 	if r.inputFormat == "yaml" || r.isInputYAML {
-		return r.evaluateYAML(in)
+		return r.parseYAML(in, handle)
 	}
-	fns := []func(io.Reader) error{
-		r.evaluateJSON,
-		r.evaluateYAML,
+	fns := []func(io.Reader, func(tree.Node) error) error{
+		r.parseJSON,
+		r.parseYAML,
 	}
 	var errs []string
 	for _, fn := range fns {
 		if _, err := in.Seek(0, io.SeekStart); err != nil {
 			return err
 		}
-		if err := fn(in); err != nil {
+		if err := fn(in, handle); err != nil {
 			errs = append(errs, err.Error())
 			if !isDecodeError(err) {
 				break
@@ -283,7 +381,7 @@ func (r *runner) evaluate(in io.ReadSeekCloser) error {
 	return errors.New(strings.Join(errs, "; "))
 }
 
-func (r *runner) evaluateJSON(in io.Reader) error {
+func (r *runner) parseJSON(in io.Reader, handle func(tree.Node) error) error {
 	dec := json.NewDecoder(in)
 	for dec.More() {
 		n, err := tree.DecodeJSON(dec)
@@ -291,18 +389,14 @@ func (r *runner) evaluateJSON(in io.Reader) error {
 			return &decodeError{err}
 		}
 		r.guessFormat = "json"
-		if err := r.evaluateNode(n); err != nil {
+		if err := handle(n); err != nil {
 			return err
 		}
-	}
-	if len(r.slurpResults) > 0 {
-		defer func() { r.slurpResults = nil }()
-		return r.output(r.slurpResults)
 	}
 	return nil
 }
 
-func (r *runner) evaluateYAML(in io.Reader) error {
+func (r *runner) parseYAML(in io.Reader, handle func(tree.Node) error) error {
 	dec := yaml.NewDecoder(in)
 	for {
 		n, err := tree.DecodeYAML(dec)
@@ -313,13 +407,9 @@ func (r *runner) evaluateYAML(in io.Reader) error {
 			return &decodeError{err}
 		}
 		r.guessFormat = "yaml"
-		if err := r.evaluateNode(n); err != nil {
+		if err := handle(n); err != nil {
 			return err
 		}
-	}
-	if len(r.slurpResults) > 0 {
-		defer func() { r.slurpResults = nil }()
-		return r.output(r.slurpResults)
 	}
 	return nil
 }
@@ -330,7 +420,7 @@ func (r *runner) evaluateNode(node tree.Node) error {
 			return err
 		}
 	}
-	expr := r.flagSet.Arg(0)
+	expr := r.queryExpr
 	if expr == "" {
 		expr = "."
 	}

--- a/cmd/tq/main_test.go
+++ b/cmd/tq/main_test.go
@@ -163,6 +163,38 @@ func TestRun(t *testing.T) {
 			caseName: "multiple yaml",
 			args:     []string{".", "testdata/book-0.yaml", "testdata/book-0.yaml"},
 			want:     mustReadFileString("testdata/book-0.yaml") + "---\n" + mustReadFileString("testdata/book-0.yaml"),
+		}, {
+			caseName: "merge default",
+			args:     []string{"--merge", "testdata/merge-a.yaml", "testdata/merge-b.yaml"},
+			golden:   "testdata/merge-default.yaml",
+		}, {
+			caseName: "merge override",
+			args:     []string{"--merge=override", "testdata/merge-a.yaml", "testdata/merge-b.yaml"},
+			golden:   "testdata/merge-override.yaml",
+		}, {
+			caseName: "merge append",
+			args:     []string{"--merge=append", "testdata/merge-a.yaml", "testdata/merge-b.yaml"},
+			golden:   "testdata/merge-append.yaml",
+		}, {
+			caseName: "merge with query",
+			args:     []string{"--merge", ".shared", "testdata/merge-a.yaml", "testdata/merge-b.yaml"},
+			golden:   "testdata/merge-shared.yaml",
+		}, {
+			caseName: "merge with edit",
+			args:     []string{"--merge", "-e", `.added = "x"`, "testdata/merge-a.yaml", "testdata/merge-b.yaml"},
+			golden:   "testdata/merge-edited.yaml",
+		}, {
+			caseName: "merge unknown strategy",
+			args:     []string{"--merge=bogus", "testdata/merge-a.yaml"},
+			errstr:   `--merge: unknown merge strategy "bogus"`,
+		}, {
+			caseName: "merge with inplace rejected",
+			args:     []string{"--merge", "-U", "testdata/merge-a.yaml"},
+			errstr:   `--merge cannot be combined with --inplace`,
+		}, {
+			caseName: "merge with slurp rejected",
+			args:     []string{"--merge", "-s", "testdata/merge-a.yaml"},
+			errstr:   `--merge cannot be combined with --slurp`,
 		},
 	}
 	for _, tc := range testCases {

--- a/cmd/tq/testdata/merge-a.yaml
+++ b/cmd/tq/testdata/merge-a.yaml
@@ -1,0 +1,7 @@
+name: a
+shared:
+  alpha: 1
+  beta: 2
+arr:
+  - 1
+  - 2

--- a/cmd/tq/testdata/merge-append.yaml
+++ b/cmd/tq/testdata/merge-append.yaml
@@ -1,0 +1,8 @@
+arr:
+  - 1
+  - 2
+extra: value
+name: a
+shared:
+  alpha: 1
+  beta: 2

--- a/cmd/tq/testdata/merge-b.yaml
+++ b/cmd/tq/testdata/merge-b.yaml
@@ -1,0 +1,9 @@
+name: b
+shared:
+  beta: 20
+  gamma: 30
+arr:
+  - 10
+  - 20
+  - 30
+extra: value

--- a/cmd/tq/testdata/merge-default.yaml
+++ b/cmd/tq/testdata/merge-default.yaml
@@ -1,0 +1,8 @@
+arr:
+  - 1
+  - 2
+extra: value
+name: a
+shared:
+  alpha: 1
+  beta: 2

--- a/cmd/tq/testdata/merge-edited.yaml
+++ b/cmd/tq/testdata/merge-edited.yaml
@@ -1,0 +1,9 @@
+added: x
+arr:
+  - 1
+  - 2
+extra: value
+name: a
+shared:
+  alpha: 1
+  beta: 2

--- a/cmd/tq/testdata/merge-override.yaml
+++ b/cmd/tq/testdata/merge-override.yaml
@@ -1,0 +1,10 @@
+arr:
+  - 10
+  - 20
+  - 30
+extra: value
+name: b
+shared:
+  alpha: 1
+  beta: 20
+  gamma: 30

--- a/cmd/tq/testdata/merge-shared.yaml
+++ b/cmd/tq/testdata/merge-shared.yaml
@@ -1,0 +1,2 @@
+alpha: 1
+beta: 2

--- a/cmd/tq/testdata/usage
+++ b/cmd/tq/testdata/usage
@@ -4,22 +4,23 @@ Usage:
   tq [flags] [query] ([file...])
 
 Flags:
-  -c, --color                  output with colors
-  -e, --edit stringArray       edit expression
-  -x, --expand                 expand results
-  -h, --help                   help for tq
-  -U, --inplace                update files, inplace
-  -i, --input-format string    input format (json or yaml)
-  -j, --input-json             alias --input-format json
-  -y, --input-yaml             alias --input-format yaml
-  -O, --output string          output file
-  -o, --output-format string   output format (json or yaml, default json)
-  -J, --output-json            alias --output-format json
-  -Y, --output-yaml            alias --output-format yaml
-  -r, --raw                    output raw strings
-  -s, --slurp                  slurp all results into an array
-  -t, --template string        golang text/template string
-  -v, --version                print version
+  -c, --color                      output with colors
+  -e, --edit stringArray           edit expression
+  -x, --expand                     expand results
+  -h, --help                       help for tq
+  -U, --inplace                    update files, inplace
+  -i, --input-format string        input format (json or yaml)
+  -j, --input-json                 alias --input-format json
+  -y, --input-yaml                 alias --input-format yaml
+  -m, --merge string[="default"]   merge inputs (optional strategy: default, override, replace, append, slurp; combine with comma)
+  -O, --output string              output file
+  -o, --output-format string       output format (json or yaml, default json)
+  -J, --output-json                alias --output-format json
+  -Y, --output-yaml                alias --output-format yaml
+  -r, --raw                        output raw strings
+  -s, --slurp                      slurp all results into an array
+  -t, --template string            golang text/template string
+  -v, --version                    print version
 
 Examples:
   % echo '{"colors": ["red", "green", "blue"]}' | tq '.colors[0]'


### PR DESCRIPTION
> Stacked on top of #88. Review #88 first; merge order is #88 → this PR.

## Summary

Exposes `tree.Merge` via tq's CLI. With `--merge` (`-m`), tq folds every parsed document from every input file into one tree before running the optional query / `--edit`, then outputs a single result.

```sh
tq --merge a.yaml b.yaml > merged.yaml
tq --merge=override base.yaml override.yaml > effective.yaml
tq --merge=override-map,append rules.d/*.yaml
tq --merge=override .servers cluster-base.yaml cluster-override.yaml
tq --merge -e '.metadata.merged = true' a.yaml b.yaml
```

### Design points

- **Strategy selection via optional flag value**: `--merge` alone uses `default`; `--merge=override` etc. picks a named strategy; `--merge=override-map,append` combines via the new `tree.MergeOptionFromString` helper from #88. `pflag.NoOptDefVal` makes the value optional.
- **Auto-detected positional layout**: tq's existing layout is `[query] [file...]`. In `--merge` mode this is awkward because most invocations have no query. New behaviour: when the first positional doesn't look like a query (i.e. doesn't start with `.` or `[`), all positionals are treated as files. This makes `tq --merge a.yaml b.yaml` (the natural form for jq/yq users) just work, while `tq --merge .shared a.yaml b.yaml` still routes the query through.
- **Conflict checks**: `--merge` is rejected with `--inplace` (multiple inputs vs. a single write target) and with `--slurp` (both accumulate; combining them has ambiguous semantics).
- **parseStream refactor**: extracts the JSON / YAML format-detection-and-loop logic from `evaluate` into a callback-driven `parseStream` helper. The existing per-file evaluator now passes `r.evaluateNode` as the callback; the new merge accumulator passes a closure that folds nodes into a single accumulator. No behaviour change to non-merge paths.

### Test data semantics

The golden files reflect `tree.Merge`'s actual semantics, including the documented quirk that `default` and `append` are **shallow** — `--merge=append a.yaml b.yaml` does NOT recurse into nested arrays unless paired with `override-map` or `slurp`. The README's strategy table calls this out so users pick the right combo.

## Test plan

- [x] `go test ./...` passes (8 new tq cases + golden files for default / override / append / query / edit, plus 3 error cases for unknown strategy / `--inplace` / `--slurp`)
- [x] `go vet ./...` clean
- [x] Existing tq tests unchanged (parseStream refactor preserves behaviour; `usage` golden regenerated to include the new flag line)
- [x] README's `Road to 1.0` no longer lists "Merge support in tq" — one item closer to v1.0

## Stacked PR

This branch was cut from `refactor/merge-cleanup` (#88), which adds `MergeOptionFromString` and the `merge.go` cleanup that this PR depends on. Base will need rebasing onto `main` once #88 merges.